### PR TITLE
Add signal configurations for Hplus_cb

### DIFF
--- a/atlas/ntuple_production/input_containers.py
+++ b/atlas/ntuple_production/input_containers.py
@@ -545,7 +545,7 @@ containers = {
     ],
     
     "Hplus_cb": [
-    ##Run 2
+    ##Run 2 (mc20 a, d and e)
     # 20 GeV H+
     "mc20_13TeV:mc20_13TeV.561444.aMCPy8EG_NNPDF30NLO_ttbar_Hplus_cb_mhc20.deriv.DAOD_PHYSLITE.e8579_a907_r14859_p6697",
     "mc20_13TeV:mc20_13TeV.561444.aMCPy8EG_NNPDF30NLO_ttbar_Hplus_cb_mhc20.deriv.DAOD_PHYSLITE.e8579_a907_r14860_p6697",
@@ -585,6 +585,39 @@ containers = {
     "mc20_13TeV:mc20_13TeV.561458.aMCPy8EG_NNPDF30NLO_ttbar_Hplus_cb_mhc130.deriv.DAOD_PHYSLITE.e8579_a907_r14859_p6697",
     "mc20_13TeV:mc20_13TeV.561458.aMCPy8EG_NNPDF30NLO_ttbar_Hplus_cb_mhc130.deriv.DAOD_PHYSLITE.e8579_a907_r14860_p6697",
     "mc20_13TeV:mc20_13TeV.561458.aMCPy8EG_NNPDF30NLO_ttbar_Hplus_cb_mhc130.deriv.DAOD_PHYSLITE.e8579_a907_r14861_p6697",
+
+    ##Run 3 (mc23a and d)
+    # 20 GeV H+
+    "mc23_13p6TeV:mc23_13p6TeV.561444.aMCPy8EG_NNPDF30NLO_ttbar_Hplus_cb_mhc20.deriv.DAOD_PHYSLITE.e8579_a910_r15540_p6697",
+    "mc23_13p6TeV:mc23_13p6TeV.561444.aMCPy8EG_NNPDF30NLO_ttbar_Hplus_cb_mhc20.deriv.DAOD_PHYSLITE.e8579_a911_r15530_p6697",
+
+    # 30 GeV H+
+    "mc23_13p6TeV:mc23_13p6TeV.561446.aMCPy8EG_NNPDF30NLO_ttbar_Hplus_cb_mhc30.deriv.DAOD_PHYSLITE.e8579_a910_r15540_p6697",
+    "mc23_13p6TeV:mc23_13p6TeV.561446.aMCPy8EG_NNPDF30NLO_ttbar_Hplus_cb_mhc30.deriv.DAOD_PHYSLITE.e8579_a911_r15530_p6697",
+
+    # 45 GeV H+
+    "mc23_13p6TeV:mc23_13p6TeV.561448.aMCPy8EG_NNPDF30NLO_ttbar_Hplus_cb_mhc45.deriv.DAOD_PHYSLITE.e8579_a910_r15540_p6697",
+    "mc23_13p6TeV:mc23_13p6TeV.561448.aMCPy8EG_NNPDF30NLO_ttbar_Hplus_cb_mhc45.deriv.DAOD_PHYSLITE.e8579_a911_r15530_p6697",
+
+    # 60 GeV H+
+    "mc23_13p6TeV:mc23_13p6TeV.561450.aMCPy8EG_NNPDF30NLO_ttbar_Hplus_cb_mhc60.deriv.DAOD_PHYSLITE.e8579_a910_r15540_p6697",
+    "mc23_13p6TeV:mc23_13p6TeV.561450.aMCPy8EG_NNPDF30NLO_ttbar_Hplus_cb_mhc60.deriv.DAOD_PHYSLITE.e8579_a911_r15530_p6697",
+
+    # 80 GeV H+
+    "mc23_13p6TeV:mc23_13p6TeV.561452.aMCPy8EG_NNPDF30NLO_ttbar_Hplus_cb_mhc80.deriv.DAOD_PHYSLITE.e8579_a910_r15540_p6697",
+    "mc23_13p6TeV:mc23_13p6TeV.561452.aMCPy8EG_NNPDF30NLO_ttbar_Hplus_cb_mhc80.deriv.DAOD_PHYSLITE.e8579_a911_r15530_p6697",
+
+    # 100 GeV H+
+    "mc23_13p6TeV:mc23_13p6TeV.561454.aMCPy8EG_NNPDF30NLO_ttbar_Hplus_cb_mhc100.deriv.DAOD_PHYSLITE.e8579_a910_r15540_p6697",
+    "mc23_13p6TeV:mc23_13p6TeV.561454.aMCPy8EG_NNPDF30NLO_ttbar_Hplus_cb_mhc100.deriv.DAOD_PHYSLITE.e8579_a911_r15530_p6697",
+
+    # 120 GeV H+
+    "mc23_13p6TeV:mc23_13p6TeV.561456.aMCPy8EG_NNPDF30NLO_ttbar_Hplus_cb_mhc120.deriv.DAOD_PHYSLITE.e8579_a910_r15540_p6697",
+    "mc23_13p6TeV:mc23_13p6TeV.561456.aMCPy8EG_NNPDF30NLO_ttbar_Hplus_cb_mhc120.deriv.DAOD_PHYSLITE.e8579_a911_r15530_p6697",
+
+    # 130 GeV H+
+    "mc23_13p6TeV:mc23_13p6TeV.561458.aMCPy8EG_NNPDF30NLO_ttbar_Hplus_cb_mhc130.deriv.DAOD_PHYSLITE.e8579_a910_r15540_p6697",
+    "mc23_13p6TeV:mc23_13p6TeV.561458.aMCPy8EG_NNPDF30NLO_ttbar_Hplus_cb_mhc130.deriv.DAOD_PHYSLITE.e8579_a911_r15530_p6697",
 ]
 
 }


### PR DESCRIPTION
Adding more signal samples:

Same H+ model but with decay into cb instead of cs (used by same analysis)

Found for mc20a , d, e and mc23a, d. 