### PR TITLE
fix: remove roastcoffea from codebase 

### DIFF
--- a/cms/src/intccms/analysis/processor.py
+++ b/cms/src/intccms/analysis/processor.py
@@ -13,7 +13,6 @@ from typing import Any, Dict, List, Optional
 
 import awkward as ak
 from coffea.processor import ProcessorABC
-from roastcoffea import track_metrics, track_time
 
 from intccms.analysis.nondiff import NonDiffAnalysis
 from intccms.skimming.io.writers import get_writer
@@ -240,7 +239,6 @@ class UnifiedProcessor(ProcessorABC):
 
         return acc
 
-    @track_metrics
     def process(self, events: ak.Array) -> Dict[str, Any]:
         """Process a single chunk of events.
 
@@ -272,14 +270,12 @@ class UnifiedProcessor(ProcessorABC):
         input_events_count = len(events)
 
         # Step 1: Apply skim selection (always applies filter)
-        with track_time(self, "skim_selection"):
-            events = self._apply_skim_selection(events)
+        events = self._apply_skim_selection(events)
         output["skimmed_events"] = len(events)
 
         # Save filtered events to disk only if save_skimmed_output is enabled
         if self.config.general.save_skimmed_output and len(events) > 0:
-            with track_time(self, "save_skimmed"):
-                self._save_skimmed_events(events, metadata)
+            self._save_skimmed_events(events, metadata)
 
         # Step 2: Run analysis if enabled
         if self.config.general.run_analysis and len(events) > 0:
@@ -287,8 +283,7 @@ class UnifiedProcessor(ProcessorABC):
             # - Object selection and corrections
             # - Histogram filling (if run_histogramming=True)
             # - Systematics (if run_systematics=True)
-            with track_time(self, "analysis"):
-                self.analysis.process(events=events, metadata=metadata)
+            self.analysis.process(events=events, metadata=metadata)
 
             # Step 3: Collect histograms if histogramming was enabled
             if self.config.general.run_histogramming:

--- a/cms/src/intccms/analysis/runner.py
+++ b/cms/src/intccms/analysis/runner.py
@@ -43,9 +43,6 @@ def run_processor_workflow(
     histograms. When run_processor=False, it loads previously saved histograms,
     enabling fast iteration on statistical models without re-processing events.
 
-    Metrics collection should be handled externally using roastcoffea's
-    MetricsCollector context manager wrapping this function call.
-
     Parameters
     ----------
     config : Config
@@ -82,19 +79,14 @@ def run_processor_workflow(
 
     Examples
     --------
-    >>> # Full processor run with metrics via roastcoffea
-    >>> from roastcoffea import MetricsCollector
-    >>> with MetricsCollector(client=client, processor_instance=processor) as collector:
-    ...     output, report = run_processor_workflow(
-    ...         config=config,
-    ...         output_manager=output_manager,
-    ...         metadata_lookup=metadata_lookup,
-    ...         workitems=workitems,
-    ...         executor=DaskExecutor(client=client),
-    ...     )
-    ...     collector.extract_metrics_from_output(output)
-    ...     collector.set_coffea_report(report)
-    >>> metrics = collector.get_metrics()
+    >>> # Full processor run
+    >>> output, report = run_processor_workflow(
+    ...     config=config,
+    ...     output_manager=output_manager,
+    ...     metadata_lookup=metadata_lookup,
+    ...     workitems=workitems,
+    ...     executor=DaskExecutor(client=client),
+    ... )
 
     >>> # Load saved histograms (iterate on statistics)
     >>> config.general.run_processor = False


### PR DESCRIPTION
This PR is a temporary measure until we get a `coffea` relase with the file handle exposed in the processor via event factory. 