### PR TITLE
Add Purdue AF as a facility option

### DIFF
--- a/cms/full_run.ipynb
+++ b/cms/full_run.ipynb
@@ -39,7 +39,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "AF=\"coffeacasa-gateway\" # options currently supported: [coffeacasa-condor, coffeacasa-gateway]\n",
+    "AF=\"coffeacasa-gateway\" # options currently supported: [coffeacasa-condor, coffeacasa-gateway, purdue-af]\n",
     "AUTO_CLOSE_CLIENT=False # the client setup is done with a contextmanager -- this flag decides if we automatically close the client as we exit the manager. If False, you handle closing manually. "
    ]
   },
@@ -250,6 +250,16 @@
     "            client.upload_file(\"/etc/cmsaf-secrets-chown/access_token\")\n",
     "            client.register_worker_callbacks(setup=set_env)\n",
     "            client.register_plugin(PipInstall(packages=dependencies))\n",
+    "\n",
+    "        elif af == \"purdue-af\":\n",
+    "            num_workers = 100\n",
+    "            from dask_gateway import Gateway\n",
+    "            gateway = Gateway()\n",
+    "            clusters = gateway.list_clusters()\n",
+    "            cluster = gateway.connect(clusters[0].name)\n",
+    "            client = cluster.get_client()\n",
+    "            cluster.scale(num_workers)\n",
+    "            client.wait_for_workers(num_workers)\n",
     "\n",
     "        else:\n",
     "            raise NotImplementedError(f\"The facility {af} is not implemented...\")\n",

--- a/cms/full_run_with_metrics.ipynb
+++ b/cms/full_run_with_metrics.ipynb
@@ -43,7 +43,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "AF=\"coffeacasa-gateway\" # options currently supported: [coffeacasa-condor, coffeacasa-gateway]\n",
+    "AF=\"coffeacasa-gateway\" # options currently supported: [coffeacasa-condor, coffeacasa-gateway, purdue-af]\n",
     "AUTO_CLOSE_CLIENT=False # the client setup is done with a contextmanager -- this flag decides if we automatically close the client as we exit the manager. If False, you handle closing manually. "
    ]
   },
@@ -255,6 +255,16 @@
     "            client.upload_file(\"/etc/cmsaf-secrets-chown/access_token\")\n",
     "            client.register_worker_callbacks(setup=set_env)\n",
     "            client.register_plugin(PipInstall(packages=dependencies))\n",
+    "\n",
+    "        elif af == \"purdue-af\":\n",
+    "            num_workers = 100\n",
+    "            from dask_gateway import Gateway\n",
+    "            gateway = Gateway()\n",
+    "            clusters = gateway.list_clusters()\n",
+    "            cluster = gateway.connect(clusters[0].name)\n",
+    "            client = cluster.get_client()\n",
+    "            cluster.scale(num_workers)\n",
+    "            client.wait_for_workers(num_workers)\n",
     "\n",
     "        else:\n",
     "            raise NotImplementedError(f\"The facility {af} is not implemented...\")\n",


### PR DESCRIPTION
Adding an `AF="purdue-af"` option which uses Dask Gateway at Purdue Analysis Facility. 