### PR TITLE
fix: race condition during merging

### DIFF
--- a/util/_dask.py
+++ b/util/_dask.py
@@ -41,7 +41,7 @@ from coffea.nanoevents import NanoEventsFactory
 from coffea.processor import Accumulatable, accumulate
 from coffea.processor.executor import WorkItem
 from coffea.util import rich_bar
-from dask.distributed import Client, as_completed
+from dask.distributed import as_completed, Client
 from dask.tokenize import tokenize
 from rich.console import Group
 from rich.live import Live


### PR DESCRIPTION
The custom processing caused `ReduceSchedulingError` instances which seemed to be more frequent with more complex workloads. Switch to `dask.distributed.as_completed` instead, which does not run into these issues based on my testing.