### PR TITLE
feat: add run_corrections flag and resilient systematics import

### DIFF
--- a/cms/example_cms/configs/configuration.py
+++ b/cms/example_cms/configs/configuration.py
@@ -13,8 +13,22 @@ from .cuts import (
     Zprime_workshop_cuts,
 )
 from .observables import get_mtt, get_mva_vars
-from .systematics import corrections_config, systematics_config
 from .skim import dataset_manager_config, skimming_config
+
+try:
+    from .systematics import corrections_config, systematics_config
+    _CORRECTIONS_AVAILABLE = True
+except (FileNotFoundError, OSError) as e:
+    import warnings
+    warnings.warn(
+        f"Could not load CMS corrections ({e.__class__.__name__}: {e}). "
+        f"Falling back to empty corrections — set run_corrections=False to "
+        f"silence this warning, or provide the correction files at "
+        f"'./example_cms/corrections/DONT_EXPOSE_CMS_INTERNAL/' to enable them."
+    )
+    corrections_config = {}
+    systematics_config = {}
+    _CORRECTIONS_AVAILABLE = False
 
 
 
@@ -48,6 +62,7 @@ general_config = {
         "run_histogramming": True,
         "run_statistics": True,
         "run_systematics": True,
+        "run_corrections": _CORRECTIONS_AVAILABLE,
         "run_plots_only": False,
         "run_mva_training": False,
         "run_metadata_generation": False,

--- a/cms/src/intccms/analysis/base.py
+++ b/cms/src/intccms/analysis/base.py
@@ -100,7 +100,14 @@ class Analysis:
         self._year_keyed_corrections = isinstance(self._corrections_config, dict)
         self._year_keyed_systematics = isinstance(self._systematics_config, dict)
 
-        self.corrlib_evaluators = self._load_correctionlib()
+        if config.general.run_corrections:
+            self.corrlib_evaluators = self._load_correctionlib()
+        else:
+            # Clear corrections so downstream loops are no-ops without
+            # touching files. _systematics_config is left untouched —
+            # run_corrections and run_systematics are independent flags.
+            self._corrections_config = {} if self._year_keyed_corrections else []
+            self.corrlib_evaluators = {}
 
     def _load_correctionlib(self) -> Dict[str, CorrectionSet]:
         """
@@ -183,7 +190,11 @@ class Analysis:
             return []
 
         if year not in self._corrections_config:
-            logger.warning(f"Year '{year}' not found in corrections config. Available: {list(self._corrections_config.keys())}")
+            # Only warn if there are other years to suggest — silent when
+            # the dict is empty (e.g. run_corrections=False or no corrections
+            # configured at all), since there's nothing useful to report.
+            if self._corrections_config:
+                logger.warning(f"Year '{year}' not found in corrections config. Available: {list(self._corrections_config.keys())}")
             return []
 
         return self._corrections_config[year]
@@ -211,7 +222,10 @@ class Analysis:
             return []
 
         if year not in self._systematics_config:
-            logger.warning(f"Year '{year}' not found in systematics config. Available: {list(self._systematics_config.keys())}")
+            # Only warn if there are other years to suggest — silent when
+            # the dict is empty, since there's nothing useful to report.
+            if self._systematics_config:
+                logger.warning(f"Year '{year}' not found in systematics config. Available: {list(self._systematics_config.keys())}")
             return []
 
         return self._systematics_config[year]

--- a/cms/src/intccms/schema/analysis.py
+++ b/cms/src/intccms/schema/analysis.py
@@ -164,6 +164,17 @@ class GeneralConfig(SubscriptableModel):
             description="If True, process systematic variations.",
         ),
     ]
+    run_corrections: Annotated[
+        bool,
+        Field(
+            default=True,
+            description="If True, load correctionlib files and apply nominal "
+            "corrections (e.g. pileup, muon SF, JEC). If False, skip "
+            "correctionlib file loading entirely and the framework runs as "
+            "if no corrections were configured. Useful for local runs "
+            "without CMS-internal correction files.",
+        ),
+    ]
     run_plots_only: Annotated[
         bool,
         Field(


### PR DESCRIPTION
## Summary

Fixes #53. Importing `example_cms.configs.configuration` no longer fails when CMS-internal correction files are absent. Adds a new `run_corrections` flag (independent of `run_systematics`) so users can also explicitly run the framework without any correction file I/O.

## Changes

- **`src/intccms/schema/analysis.py`**: new `run_corrections: bool` field on `GeneralConfig`, default `True`.
- **`src/intccms/analysis/base.py`**: gate `_load_correctionlib()` on the flag; clear `_corrections_config` to empty when off; suppress the year-not-found warnings on empty configs to avoid per-chunk log spam.
- **`example_cms/configs/configuration.py`**: wrap the systematics import in try/except, fall back to empty configs with a single user warning, wire `run_corrections=_CORRECTIONS_AVAILABLE`.