### PR TITLE
chore: rename skimming notebooks and update descriptions

### DIFF
--- a/cms/README.md
+++ b/cms/README.md
@@ -348,11 +348,12 @@ This shows where worker CPU time is spent (decompression, network I/O, array con
 
 ## Notebooks
 
-| Notebook | Use when |
-|----------|----------|
+| Notebook | Purpose |
+|----------|---------|
 | `full_run.ipynb` | Standard analysis workflow (metadata &rarr; processing &rarr; histograms) |
-| `full_run_with_metrics.ipynb` | Same workflow with roastcoffea dashboards |
-| `full_run_with_skimming.ipynb` | Demonstrates all four workflow modes |
+| `full_run_with_metrics.ipynb` | Same workflow with roastcoffea performance dashboards |
+| `full_run_workflow_modes.ipynb` | Runs all four workflow modes (skim+analysis, analysis only, skim only, analysis on skims) with per-mode metrics comparison |
+| `full_run_skim_formats.ipynb` | Tests skimming output formats (Parquet/S3, TTree/XRootD, RNTuple/XRootD) with read-back verification |
 | `full_run_200gbps.ipynb` | I/O throughput benchmark with profiling |
 | `input_inspector.ipynb` | Characterize inputs (event counts, branch sizes, compression) |
 

--- a/cms/full_run_skim_formats.ipynb
+++ b/cms/full_run_skim_formats.ipynb
@@ -5,11 +5,9 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# CMS Z' single-lepton: Skimming\n",
+    "# Skimming output formats\n",
     "\n",
-    "This notebook extends the full_run workflow to focus on skimming: filtering events and saving to disk in a configurable output format. Supports Parquet on S3, ROOT TTree on XRootD, and ROOT RNTuple on XRootD.\n",
-    "\n",
-    "A verification cell at the end reads back all skimmed files and checks event counts."
+    "Skim events and save to disk using different output backends: Parquet (local or S3), ROOT TTree (local or XRootD), and ROOT RNTuple (local or XRootD). A verification cell reads back all skimmed files and checks event counts. A second pass demonstrates re-running the analysis on the saved skims (`use_skimmed_input=True`)."
    ]
   },
   {

--- a/cms/full_run_workflow_modes.ipynb
+++ b/cms/full_run_workflow_modes.ipynb
@@ -4,19 +4,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# CMS Z' single-lepton: Skimming workflows\n",
+    "# Workflow modes\n",
     "\n",
-    "This notebook demonstrates the four skimming workflow modes supported by the processor,\n",
-    "with performance metrics collected via [roastcoffea](https://github.com/MoAly98/roastcoffea).\n",
+    "Demonstrates the four workflow modes supported by the processor, with performance metrics collected via [roastcoffea](https://github.com/MoAly98/roastcoffea). Each mode cell is independent — run any subset in any order (Mode 4 requires skimmed files from Mode 1 or 3).\n",
     "\n",
     "| Mode | `save_skimmed_output` | `run_analysis` | Description |\n",
     "|------|-----------------------|----------------|-------------|\n",
     "| **1. Skim + Analysis** | `True` | `True` | Skim events to disk **and** run histogramming in one pass |\n",
     "| **2. Analysis only** | `False` | `True` | Apply skim filter on-the-fly, no files saved |\n",
     "| **3. Skim only** | `True` | `False` | Save skimmed files to disk, skip histogramming |\n",
-    "| **4. Analysis on skimmed** | `False` | `True` | Read previously skimmed files as input (`use_skimmed_input=True`) |\n",
-    "\n",
-    "Each mode cell is independent — run any subset in any order (Mode 4 requires skimmed files from Mode 1 or 3)."
+    "| **4. Analysis on skimmed** | `False` | `True` | Read previously skimmed files as input (`use_skimmed_input=True`) |"
    ]
   },
   {


### PR DESCRIPTION
## Summary

- renames `full_run_skimming.ipynb` to `full_run_skim_formats.ipynb` (focuses on output format testing: Parquet/S3, TTree/XRootD, RNTuple/XRootD)
- renames `full_run_with_skimming.ipynb` to `full_run_workflow_modes.ipynb` (demonstrates the 4 workflow modes with metrics)
- updates title and summary markdown cells in both notebooks to reflect their purpose
- updates README notebook table with new names and clearer descriptions