### PR TITLE
docs: rewrite README as FAQ guide, rename notebooks, add skim inspector

### DIFF
--- a/cms/README.md
+++ b/cms/README.md
@@ -117,6 +117,28 @@ Set `config["general"]["run_metadata_generation"] = True` to run it (requires a 
 
 **Re-run when**: datasets change, files are added/removed, or you switch redirectors.
 
+### [Advanced] What are the components of the preprocessing workflow?
+
+The metadata extraction pipeline lives in `src/intccms/metadata_extractor/` and has four components:
+
+| Module | Class/Functions | Role |
+|--------|----------------|------|
+| `manager.py` | `DatasetMetadataManager` | Top-level orchestrator. Calls the builder and extractor in sequence, caches results as JSON, and builds `metadata_lookup` for the processor. |
+| `builders.py` | `FilesetBuilder` | Reads dataset configs from `DatasetManager`, enumerates file paths (applying `skip_files`), and builds a coffea-compatible fileset dict + `Dataset` objects. |
+| `extractor.py` | `CoffeaMetadataExtractor` | Runs coffea's preprocessing over the fileset using a `Runner` with the configured executor (Dask or local). Produces `WorkItem` objects with file paths, entry ranges, and chunk boundaries. |
+| `core.py` | `parse_dataset_key`, `aggregate_workitem_events`, `format_event_summary` | Pure functions for dataset key parsing, event count aggregation across workitems, and summary formatting. |
+| `io.py` | `collect_file_paths`, `save_json`, `load_json`, `serialize_workitems` | File I/O helpers: path enumeration from dataset directories, JSON persistence for fileset/workitems/summaries. |
+
+The flow when `run_metadata_generation=True`:
+
+1. `DatasetMetadataManager.run(executor=...)` is called
+2. `FilesetBuilder.build_fileset()` enumerates files from dataset directories → produces `fileset` dict and `Dataset` objects
+3. `CoffeaMetadataExtractor.extract_metadata(fileset)` runs coffea preprocessing on workers → produces `WorkItem` list with chunked entry ranges
+4. Results are saved to `metadata_dir/` as JSON (`fileset.json`, `workitems.json`, `nanoaods.json`)
+5. `build_metadata_lookup()` combines dataset configs with event counts into a `MetadataLookup` dict keyed by dataset name, containing process, xsec, nevts, is_data, year, etc.
+
+When `run_metadata_generation=False`, step 2-3 are skipped and cached JSON files are loaded instead.
+
 ## Handling bad files
 
 There are two levels of protection against bad files:

--- a/cms/README.md
+++ b/cms/README.md
@@ -348,11 +348,12 @@ This shows where worker CPU time is spent (decompression, network I/O, array con
 
 ## Notebooks
 
-| Notebook | Use when |
-|----------|----------|
+| Notebook | Purpose |
+|----------|---------|
 | `full_run.ipynb` | Standard analysis workflow (metadata &rarr; processing &rarr; histograms) |
-| `full_run_with_metrics.ipynb` | Same workflow with roastcoffea dashboards |
-| `full_run_with_skimming.ipynb` | Demonstrates all four workflow modes |
+| `full_run_with_metrics.ipynb` | Same workflow with roastcoffea performance dashboards |
+| `full_run_workflow_modes.ipynb` | Runs all four workflow modes (skim+analysis, analysis only, skim only, analysis on skims) with per-mode metrics comparison |
+| `full_run_skim_formats.ipynb` | Tests skimming output formats (Parquet/S3, TTree/XRootD, RNTuple/XRootD) with read-back verification |
 | `full_run_200gbps.ipynb` | I/O throughput benchmark with profiling |
 | `input_inspector.ipynb` | Characterize inputs (event counts, branch sizes, compression) |
 

--- a/cms/README.md
+++ b/cms/README.md
@@ -2,7 +2,20 @@
 
 A coffea-based distributed analysis framework for the CMS Z' → tt̄ single-lepton search on Run 2 NanoAOD.
 
-**Contents**: [Setup](#setup) | [Configuration](#configuration) | [Datasets](#datasets) | [Metadata generation](#metadata-generation) | [Handling bad files](#handling-bad-files) | [Workflow modes](#workflow-modes) | [Skimming](#skimming) | [The processor](#the-processor) | [Histogramming](#histogramming) | [Corrections and systematics](#corrections-and-systematics) | [Metrics and profiling](#metrics-and-profiling) | [Notebooks](#notebooks) | [Credentials](#credentials)
+**Contents**
+- [Setup](#setup)
+- [Configuration](#configuration)
+- [Datasets](#datasets)
+- [Metadata generation](#metadata-generation)
+- [Handling bad files](#handling-bad-files)
+- [Workflow modes](#workflow-modes)
+- [Skimming](#skimming)
+- [The processor](#the-processor)
+- [Histogramming](#histogramming)
+- [Corrections and systematics](#corrections-and-systematics)
+- [Metrics and profiling](#metrics-and-profiling)
+- [Notebooks](#notebooks)
+- [Credentials](#credentials)
 
 ## Setup
 

--- a/cms/README.md
+++ b/cms/README.md
@@ -1,6 +1,8 @@
 # CMS integration challenge
 
-A coffea-based distributed analysis framework for the CMS Z' &rarr; t&tbar; single-lepton search on Run 2 NanoAOD.
+A coffea-based distributed analysis framework for the CMS Z' → tt̄ single-lepton search on Run 2 NanoAOD.
+
+**Contents**: [Setup](#setup) | [Configuration](#configuration) | [Datasets](#datasets) | [Metadata generation](#metadata-generation) | [Handling bad files](#handling-bad-files) | [Workflow modes](#workflow-modes) | [Skimming](#skimming) | [The processor](#the-processor) | [Histogramming](#histogramming) | [Corrections and systematics](#corrections-and-systematics) | [Metrics and profiling](#metrics-and-profiling) | [Notebooks](#notebooks) | [Credentials](#credentials)
 
 ## Setup
 
@@ -101,6 +103,31 @@ Metadata generation runs coffea preprocessing: enumerates files, counts events, 
 Set `config["general"]["run_metadata_generation"] = True` to run it (requires a Dask client). Results are cached locally, so set it to `False` on subsequent runs.
 
 **Re-run when**: datasets change, files are added/removed, or you switch redirectors.
+
+## Handling bad files
+
+There are two levels of protection against bad files:
+
+### Skipping known bad files before processing
+
+If you know specific files are corrupted, exclude them via `skip_files` in the dataset config. Any file whose path contains one of these strings is filtered out during dataset building (before metadata generation or processing):
+
+```python
+config["datasets"]["skip_files"] = [
+    "92D0BDF3-91AE-514F-88B5-8F591450B8AD.root",
+    "8E2613E5-9327-D644-9567-C3A5CE721D27.root",
+]
+```
+
+### Tolerating bad files during processing
+
+Both the metadata extractor and the processor runner use coffea's `skipbadfiles` parameter to catch and skip files that fail at read time. The errors caught include `OSError`, `LZMAError`, `DecompressionError`, `DeserializationError`, and `AssertionError`.
+
+This is configured in:
+- `src/intccms/metadata_extractor/extractor.py` (preprocessing)
+- `src/intccms/analysis/runner.py` (processing)
+
+To change which errors are tolerated, edit the `skipbadfiles` tuple in the `Runner(...)` constructor call in those files. Setting `skipbadfiles=False` disables this and makes any bad file a hard failure.
 
 ## Workflow modes
 

--- a/cms/README.md
+++ b/cms/README.md
@@ -14,6 +14,7 @@ A coffea-based distributed analysis framework for the CMS Z' → tt̄ single-lep
 - [Histogramming](#histogramming)
 - [Corrections and systematics](#corrections-and-systematics)
 - [Metrics and profiling](#metrics-and-profiling)
+- [Inspecting inputs](#inspecting-inputs)
 - [Notebooks](#notebooks)
 - [Credentials](#credentials)
 
@@ -430,6 +431,27 @@ save(fig)
 
 This shows where worker CPU time is spent (decompression, network I/O, array construction, etc.). The "time" values are cumulative across all workers.
 
+## Inspecting inputs
+
+### How do I inspect NanoAOD input files?
+
+`input_inspector.ipynb` uses the `intccms.metrics.inspector` module to characterize input ROOT files. It runs distributed inspection via Dask and reports:
+- Event counts per file and per dataset
+- Branch sizes (compressed and uncompressed)
+- Compression ratios
+- Optional Rucio-backed file size lookups
+
+The inspector produces rich tables (via `rich`) and matplotlib visualizations (event distributions, branch size distributions, dataset comparisons, summary dashboard).
+
+### How do I inspect skimmed output files?
+
+`skim_inspector.ipynb` uses the same inspector module but pointed at skimmed files on XRootD (or other remote storage). It:
+1. Derives skimmed subdirectory paths from the original dataset config and a configurable `SKIM_BASE` / `SKIM_REDIRECTOR`
+2. Lists files via `xrdfs ls`
+3. Runs the same distributed inspection and visualization pipeline
+
+To use it, edit the `SKIM_REDIRECTOR` and `SKIM_BASE` variables in the config cell to point at your skimmed file location.
+
 ## Notebooks
 
 | Notebook | Purpose |
@@ -439,7 +461,8 @@ This shows where worker CPU time is spent (decompression, network I/O, array con
 | `full_run_workflow_modes.ipynb` | Runs all four workflow modes (skim+analysis, analysis only, skim only, analysis on skims) with per-mode metrics comparison |
 | `full_run_skim_formats.ipynb` | Tests skimming output formats (Parquet/S3, TTree/XRootD, RNTuple/XRootD) with read-back verification |
 | `full_run_200gbps.ipynb` | I/O throughput benchmark with profiling |
-| `input_inspector.ipynb` | Characterize inputs (event counts, branch sizes, compression) |
+| `input_inspector.ipynb` | Inspect NanoAOD input files (event counts, branch sizes, compression) |
+| `skim_inspector.ipynb` | Inspect skimmed output files on XRootD or other remote storage |
 
 ## Credentials
 

--- a/cms/README.md
+++ b/cms/README.md
@@ -194,11 +194,23 @@ Set `use_skimmed_input=True` in the config. The runner auto-discovers skimmed fi
 
 ## The processor
 
-### Where does it live?
+### How is the analysis code organized?
+
+Three layers in `src/intccms/analysis/`:
+
+| File | Class | Role |
+|------|-------|------|
+| `base.py` | `Analysis` | Generic base class. Handles corrections (correctionlib + custom functions), object masks, baseline selection, ghost observables. Experiment-agnostic. |
+| `cms.py` | `CMSAnalysis(Analysis)` | CMS-specific implementation. Initializes histograms, runs the histogramming loop (nominal + systematic variations), runs statistical inference via cabinetry. |
+| `processors.py` | `SkimAndAnalyseProcessor`, `TwoHundredGbpsProcessor` | Coffea processors. `SkimAndAnalyseProcessor` owns a `CMSAnalysis` instance and dispatches to it for the analysis step. |
+
+The flow per chunk: `SkimAndAnalyseProcessor.process()` → skim selection → optionally save to disk → `CMSAnalysis.process()` → `Analysis.prepare_objects()` (corrections + masks) → `CMSAnalysis.histogramming()` (fill histograms).
+
+### Where does the processor live?
 
 `src/intccms/analysis/processors.py` has two processors:
 
-- **`SkimAndAnalyseProcessor`**: The main processor. Per chunk, it: (1) applies skim selection, (2) saves filtered events to disk if enabled, (3) runs analysis (corrections + histogramming) if enabled. All controlled by the config flags above.
+- **`SkimAndAnalyseProcessor`**: The main processor. Per chunk, it: (1) applies skim selection, (2) saves filtered events to disk if enabled, (3) calls `CMSAnalysis.process()` for corrections and histogramming if enabled. All controlled by the config flags above.
 - **`TwoHundredGbpsProcessor`**: Minimal I/O benchmark. Reads and materializes configured branches, returns event count only.
 
 Both are passed to `run_processor_workflow()` in `src/intccms/analysis/runner.py`.
@@ -265,14 +277,24 @@ Channels (in `configuration.py`) tie a selection function to a list of observabl
 }
 ```
 
+### How are histograms initialized?
+
+`CMSAnalysis._init_histograms()` in `src/intccms/analysis/cms.py` creates one `hist.Hist` per (channel, observable) combination. Each histogram has three axes:
+
+- **Observable** (`hist.axis.Variable`): binning from the observable config
+- **Process** (`hist.axis.StrCategory`, growth): filled dynamically with dataset names
+- **Variation** (`hist.axis.StrCategory`, growth): `"nominal"` plus one entry per systematic up/down
+
+Storage is `hist.storage.Weight()` (supports weighted events). The histograms are created once during processor initialization and filled per chunk.
+
 ### Where does histogramming happen?
 
-`CMSAnalysis.histogramming()` in `src/intccms/analysis/cms.py`. For each chunk, it:
+`CMSAnalysis.histogramming()` in the same file. For each chunk, it:
 
 1. Applies the channel selection
 2. Computes event weights (genWeight &times; xsec normalization &times; correction SFs)
 3. Evaluates the observable function
-4. Fills a `hist.Hist` with axes: observable (Variable), process (StrCategory), variation (StrCategory)
+4. Fills the histogram for the matching (process, variation) bin
 
 ### Where are histograms saved?
 

--- a/cms/full_run_skim_formats.ipynb
+++ b/cms/full_run_skim_formats.ipynb
@@ -5,11 +5,9 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# CMS Z' single-lepton: Skimming\n",
+    "# Skimming output formats\n",
     "\n",
-    "This notebook extends the full_run workflow to focus on skimming: filtering events and saving to disk in a configurable output format. Supports Parquet on S3, ROOT TTree on XRootD, and ROOT RNTuple on XRootD.\n",
-    "\n",
-    "A verification cell at the end reads back all skimmed files and checks event counts."
+    "Skim events and save to disk using different output backends: Parquet (local or S3), ROOT TTree (local or XRootD), and ROOT RNTuple (local or XRootD). A verification cell reads back all skimmed files and checks event counts. A second pass demonstrates re-running the analysis on the saved skims (`use_skimmed_input=True`)."
    ]
   },
   {

--- a/cms/full_run_workflow_modes.ipynb
+++ b/cms/full_run_workflow_modes.ipynb
@@ -4,19 +4,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# CMS Z' single-lepton: Skimming workflows\n",
+    "# Workflow modes\n",
     "\n",
-    "This notebook demonstrates the four skimming workflow modes supported by the processor,\n",
-    "with performance metrics collected via [roastcoffea](https://github.com/MoAly98/roastcoffea).\n",
+    "Demonstrates the four workflow modes supported by the processor, with performance metrics collected via [roastcoffea](https://github.com/MoAly98/roastcoffea). Each mode cell is independent — run any subset in any order (Mode 4 requires skimmed files from Mode 1 or 3).\n",
     "\n",
     "| Mode | `save_skimmed_output` | `run_analysis` | Description |\n",
     "|------|-----------------------|----------------|-------------|\n",
     "| **1. Skim + Analysis** | `True` | `True` | Skim events to disk **and** run histogramming in one pass |\n",
     "| **2. Analysis only** | `False` | `True` | Apply skim filter on-the-fly, no files saved |\n",
     "| **3. Skim only** | `True` | `False` | Save skimmed files to disk, skip histogramming |\n",
-    "| **4. Analysis on skimmed** | `False` | `True` | Read previously skimmed files as input (`use_skimmed_input=True`) |\n",
-    "\n",
-    "Each mode cell is independent — run any subset in any order (Mode 4 requires skimmed files from Mode 1 or 3)."
+    "| **4. Analysis on skimmed** | `False` | `True` | Read previously skimmed files as input (`use_skimmed_input=True`) |"
    ]
   },
   {

--- a/cms/skim_inspector.ipynb
+++ b/cms/skim_inspector.ipynb
@@ -1,0 +1,628 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Skimmed file inspector\n",
+    "\n",
+    "Inspect skimmed output files stored on XRootD (or other remote backends). Uses the same `intccms.metrics.inspector` module as `input_inspector.ipynb`, but pointed at skimmed files instead of original NanoAOD.\n",
+    "\n",
+    "The notebook:\n",
+    "1. Derives skimmed file paths from the original dataset config and a remote skim location\n",
+    "2. Lists files on XRootD via `xrdfs ls`\n",
+    "3. Runs distributed inspection with Dask (event counts, branch sizes, compression ratios)\n",
+    "4. Aggregates and visualizes statistics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import copy\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# Add src directory to Python path\n",
+    "repo_root = Path.cwd()\n",
+    "src_dir = repo_root / \"src\"\n",
+    "examples_dir = repo_root/\"example_cms\"\n",
+    "if str(src_dir) not in sys.path:\n",
+    "    sys.path.insert(0, str(src_dir))\n",
+    "if str(examples_dir) not in sys.path:\n",
+    "    sys.path.insert(0, str(examples_dir))\n",
+    "print(f\"✅ Added {src_dir} to Python path\")\n",
+    "print(f\"✅ Added {examples_dir} to Python path\")\n",
+    "\n",
+    "\n",
+    "from dask.distributed import Client, PipInstall\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "import cloudpickle\n",
+    "import intccms\n",
+    "import example_cms\n",
+    "\n",
+    "# Register modules for cloud pickle\n",
+    "cloudpickle.register_pickle_by_value(intccms)\n",
+    "cloudpickle.register_pickle_by_value(example_cms)\n",
+    "\n",
+    "from intccms.datasets import DatasetManager\n",
+    "from intccms.metrics.inspector import (\n",
+    "    extract_files_from_dataset_manager,\n",
+    "    get_dataset_file_counts,\n",
+    "    inspect_dataset_distributed,\n",
+    "    aggregate_statistics,\n",
+    "    group_by_dataset,\n",
+    "    compute_dataset_statistics,\n",
+    "    compute_compression_stats,\n",
+    "    format_error_summary,\n",
+    "    plot,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def acquire_client():\n",
+    "    client = Client(\"tls://localhost:8786\")\n",
+    "    cluster = None  # no local cluster in this mode\n",
+    "    return client, cluster"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1: Load Dataset Configuration\n",
+    "\n",
+    "Load the dataset configuration from `example_cms/configs/skim.py`.\n",
+    "This uses the same configuration as your processing workflow."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from example_cms.configs.configuration import config as original_config                                                                                                               \n",
+    "from intccms.schema import Config, DatasetManagerConfig, load_config_with_restricted_cli                                                                                              \n",
+    "                                                                                                                                                                                    \n",
+    "# Load original config to get process names and directory counts                                                                                                                      \n",
+    "config = copy.deepcopy(original_config)\n",
+    "cli_args = []\n",
+    "full_config = load_config_with_restricted_cli(config, cli_args)                                                                                                                       \n",
+    "validated_config = Config(**full_config)\n",
+    "original_dm = DatasetManager(validated_config.datasets)                                                                                                                               \n",
+    "                       \n",
+    "# Skimmed file location\n",
+    "SKIM_REDIRECTOR = \"root://xrootd-local.unl.edu:1094/\"\n",
+    "SKIM_BASE = \"/store/user/oshadura/skim_rntuple\"                                                                                                                                       \n",
+    "\n",
+    "# Derive skimmed subdirectory names and build a new DatasetManager                                                                                                                    \n",
+    "skimmed_datasets = []    \n",
+    "dataset_process_map = {}                                                                                                                                                              \n",
+    "for process_name in original_dm.list_processes():\n",
+    "  n_dirs = len(original_dm.get_dataset_directories(process_name))\n",
+    "  is_data = original_dm.is_data_dataset(process_name)                                                                                                                               \n",
+    "  xsecs = original_dm.get_cross_section(process_name)\n",
+    "                                                                                                                                                                                    \n",
+    "  subdirs = []         \n",
+    "  for i in range(n_dirs):                                                                                                                                                           \n",
+    "      subdir = f\"{process_name}_{i}\" if is_data else f\"{process_name}_{i}__nominal\"\n",
+    "      subdirs.append(subdir)                                                                                                                                                        \n",
+    "      dataset_process_map[subdir] = process_name\n",
+    "                                                                                                                                                                                    \n",
+    "  skimmed_datasets.append({\n",
+    "      \"name\": process_name,\n",
+    "      \"directories\": tuple(f\"{SKIM_BASE}/{sd}/\" for sd in subdirs),\n",
+    "      \"cross_sections\": tuple(xsecs) if len(xsecs) > 1 else xsecs[0],                                                                                                               \n",
+    "      \"tree_name\": \"Events\",                                                                                                                                                        \n",
+    "      \"redirector\": SKIM_REDIRECTOR,                                                                                                                                                \n",
+    "      \"is_data\": is_data,                                                                                                                                                           \n",
+    "  })                                                                                                                                                                                \n",
+    "                       \n",
+    "dm = DatasetManager(DatasetManagerConfig(datasets=skimmed_datasets))                                                                                                                  \n",
+    "\n",
+    "print(f\"Available datasets ({len(dm.list_processes())} processes):\")                                                                                                                  \n",
+    "for name in dm.list_processes():\n",
+    "  n_dirs = len(dm.get_dataset_directories(name))\n",
+    "  print(f\"  {name}: {n_dirs} subdirs\")            "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2: Quick File Count Summary\n",
+    "\n",
+    "Get a quick count of files per dataset without full inspection."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# from collections import Counter                                                                                                                                                       \n",
+    "                       \n",
+    "# file_counts = Counter(dataset_map.values())\n",
+    "\n",
+    "# print(\"\\nFile counts per dataset:\")\n",
+    "# for dataset, count in sorted(file_counts.items()):\n",
+    "#   print(f\"  {dataset}: {count} files\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3: Extract Files for Inspection\n",
+    "\n",
+    "Extract file paths from DatasetManager. You can:\n",
+    "- Inspect all datasets\n",
+    "- Inspect specific processes\n",
+    "- Limit files per process (useful for quick sampling)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import subprocess                                                                                                                                                                     \n",
+    "\n",
+    "file_list = []                                                                                                                                                                        \n",
+    "dataset_map = {}         \n",
+    "\n",
+    "for subdir in dataset_process_map:                                                                                                                                                          \n",
+    "  remote_path = f\"{SKIM_BASE}/{subdir}/\"\n",
+    "  result = subprocess.run(                                                                                                                                                          \n",
+    "      [\"xrdfs\", \"xrootd-local.unl.edu:1094\", \"ls\", remote_path],\n",
+    "      capture_output=True, text=True,                                                                                                                                               \n",
+    "  )\n",
+    "  if result.returncode != 0:                                                                                                                                                        \n",
+    "      print(f\"  WARNING: failed to list {subdir}: {result.stderr.strip()}\")\n",
+    "      continue\n",
+    "\n",
+    "  files = [\n",
+    "      f\"{SKIM_REDIRECTOR}{line.strip()}\"\n",
+    "      for line in result.stdout.splitlines()                                                                                                                                        \n",
+    "      if line.strip().endswith(\".root\")\n",
+    "  ]                                                                                                                                                                                 \n",
+    "                       \n",
+    "  process_name = dataset_process_map[subdir]\n",
+    "  for f in files:\n",
+    "      file_list.append(f)\n",
+    "      dataset_map[f] = process_name                                                                                                                                                 \n",
+    "\n",
+    "print(f\"\\nExtracted {len(file_list)} files for inspection\")                                                                                                                           \n",
+    "print(f\"Example file: {file_list[0]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 4: Distributed Inspection with Dask\n",
+    "\n",
+    "Run distributed file inspection using Dask.\n",
+    "This extracts metadata from all files in parallel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    # Start a local Dask cluster\n",
+    "    client, _ = acquire_client()\n",
+    "    print(f\"Dask dashboard: {client.dashboard_link}\")\n",
+    "    # Run distributed inspection\n",
+    "    # Note: max_branches limits the number of branches inspected per file for faster results\n",
+    "    results, errors = inspect_dataset_distributed(\n",
+    "        client,\n",
+    "        file_list,\n",
+    "        max_branches=500,  # Limit to first 100 branches for speed\n",
+    "    )\n",
+    "    \n",
+    "    # Print formatted error summary\n",
+    "    print(format_error_summary(errors))\n",
+    "    \n",
+    "    if results:\n",
+    "        print(f\"\\n=== Example Result ===\")\n",
+    "        print(f\"  File: {results[0]['filepath']}\")\n",
+    "        print(f\"  Events: {results[0]['num_events']:,}\")\n",
+    "        print(f\"  Branches: {results[0]['num_branches']}\")\n",
+    "    else:\n",
+    "        print(\"\\nNo files were successfully inspected!\")\n",
+    "        \n",
+    "finally:\n",
+    "    client.close()\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 5: Aggregate Statistics\n",
+    "\n",
+    "Compute aggregate statistics across all inspected files."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Optional: Fetch File Sizes from Rucio\n",
+    "\n",
+    "Use the inspector's Rucio helper to retrieve authoritative file sizes. This\n",
+    "requires a valid Rucio environment (credentials and network access). If the\n",
+    "lookup fails, the notebook continues with locally derived statistics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from intccms.metrics.inspector import rucio as inspector_rucio\n",
+    "from rich.console import Console\n",
+    "\n",
+    "size_summary = None\n",
+    "try:\n",
+    "    size_summary = inspector_rucio.fetch_file_sizes(\n",
+    "        dm,\n",
+    "        processes=[\"signal\", \"ttbar_semilep\"],\n",
+    "        max_files_per_process=5,\n",
+    "    )\n",
+    "    console = Console(force_jupyter=False)\n",
+    "    console.print(inspector_rucio.format_dataset_size_table(size_summary))\n",
+    "except Exception as exc:\n",
+    "    print(\"Skipping Rucio size lookup (set size_summary=None):\", exc)\n",
+    "    size_summary = None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rich.console import Console\n",
+    "from intccms.metrics.inspector import (\n",
+    "    format_overall_stats_table,\n",
+    "    format_branch_stats_table,\n",
+    "    format_dataset_stats_table,\n",
+    "    format_compression_stats_table,\n",
+    ")\n",
+    "\n",
+    "# Create console\n",
+    "console = Console(force_jupyter=False)\n",
+    "\n",
+    "# Aggregate and display statistics\n",
+    "stats = aggregate_statistics(results, size_summary=None)\n",
+    "table = format_overall_stats_table(stats)\n",
+    "console.print(table)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 6: Branch statistics\n",
+    "\n",
+    "Analyze branch size and compression distributions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from intccms.metrics.inspector.aggregator import compute_branch_statistics\n",
+    "\n",
+    "branch_stats = compute_branch_statistics(results)\n",
+    "\n",
+    "table = format_branch_stats_table(branch_stats)\n",
+    "console.print(table)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 7: Per-Dataset Statistics\n",
+    "\n",
+    "Group results by dataset and compute per-dataset statistics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Group by dataset\n",
+    "grouped = group_by_dataset(results, dataset_map)\n",
+    "\n",
+    "# Compute per-dataset statistics\n",
+    "dataset_stats = compute_dataset_statistics(grouped)\n",
+    "\n",
+    "# Display as rich table\n",
+    "table = format_dataset_stats_table(dataset_stats)\n",
+    "console.print(table)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 8: Compression Statistics\n",
+    "\n",
+    "Analyze compression ratios across all files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "compression_stats = compute_compression_stats(results)\n",
+    "# Display as rich table\n",
+    "table = format_compression_stats_table(compression_stats)\n",
+    "console.print(table)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 9: Visualizations\n",
+    "\n",
+    "Create plots to visualize the inspection results."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Events per file ratio by dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Events per file ratio by dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plot.plot_events_per_file_by_dataset(dataset_stats)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Event Distribution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plot.plot_event_distribution(results)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Dataset Comparison"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, (ax1, ax2) = plot.plot_dataset_comparison(dataset_stats)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Understanding Box Plots\n",
+    "\n",
+    "The box plots in this analysis show statistical distributions:\n",
+    "\n",
+    "- **Box**: Contains the middle 50% of data (interquartile range, IQR)\n",
+    "- **Line inside box**: Median value (50th percentile)\n",
+    "- **Whiskers**: Extend to the 5th and 95th percentiles\n",
+    "- **Points beyond whiskers**: Outliers outside the 5th-95th percentile range\n",
+    "\n",
+    "This visualization helps identify data skewness, outliers, and distribution characteristics.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Branch Size Distribution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plot.plot_branch_size_distribution(results)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Branch Compression Distribution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plot.plot_branch_compression_distribution(results)\n",
+    "if fig is not None:\n",
+    "    plt.show()\n",
+    "else:\n",
+    "    print(\"No compression data available\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Branch Distributions by Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, (ax1, ax2) = plot.plot_branch_distributions_by_dataset(results, dataset_map)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### File Size Distribution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plot.plot_file_size_distribution(results)\n",
+    "if fig is not None:\n",
+    "    plt.show()\n",
+    "else:\n",
+    "    print(\"No file size data available (all files are remote)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Summary Dashboard\n",
+    "\n",
+    "Create a comprehensive dashboard with all key plots."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plot.plot_summary_dashboard(results, dataset_stats, dataset_map)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 10: Save Results\n",
+    "\n",
+    "You can save plots to files and export statistics to JSON."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "# Save summary dashboard\n",
+    "# fig = plot.plot_summary_dashboard(\n",
+    "#     results, dataset_stats, top_branches,\n",
+    "#     save_path=\"input_summary.png\"\n",
+    "# )\n",
+    "\n",
+    "# Export statistics to JSON\n",
+    "# output = {\n",
+    "#     \"overall_stats\": stats,\n",
+    "#     \"dataset_stats\": dataset_stats,\n",
+    "#     \"compression_stats\": compression_stats,\n",
+    "#     \"top_branches\": [\n",
+    "#         {\"name\": name, \"size_bytes\": size, \"compression_ratio\": ratio}\n",
+    "#         for name, size, ratio in top_branches\n",
+    "#     ],\n",
+    "# }\n",
+    "# \n",
+    "# with open(\"inspection_results.json\", \"w\") as f:\n",
+    "#     json.dump(output, f, indent=2)\n",
+    "\n",
+    "print(\"Done! You can save plots and export statistics as needed.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary

- rewrites README as a practical FAQ guide covering config structure, datasets, metadata generation, workflow modes, skimming options, processors, histogramming, systematics, metrics, and credentials
- adds table of contents, analysis module architecture breakdown (base.py → cms.py → processors.py), histogram initialization details, advanced metadata extraction pipeline breakdown, bad files handling section, and input inspection section
- renames `full_run_skimming.ipynb` → `full_run_skim_formats.ipynb` and `full_run_with_skimming.ipynb` → `full_run_workflow_modes.ipynb` with updated titles and summaries
- adds `skim_inspector.ipynb` for inspecting skimmed output files on XRootD