### PR TITLE
fix: wrap import that triggers histserv dependency in try-except

### DIFF
--- a/cms/src/intccms/analysis/processors.py
+++ b/cms/src/intccms/analysis/processors.py
@@ -11,13 +11,12 @@ import uuid
 from collections import defaultdict
 from pathlib import Path
 from typing import Any, Dict, List
+from warnings import warn
 
 import awkward as ak
 from coffea.processor import ProcessorABC
 from roastcoffea import track_memory, track_metrics, track_time
 
-from intccms.analysis.cms import CMSAnalysis
-from intccms.analysis.histserv import HistServAnalysis
 from intccms.skimming.io.writers import get_writer
 from intccms.skimming.pipeline.stages import (
     build_column_list,
@@ -32,6 +31,11 @@ from intccms.utils.output import (
 )
 from intccms.schema import Config
 from intccms.utils.functors import SelectionExecutor
+from intccms.analysis.cms import CMSAnalysis
+try:
+    from intccms.analysis.histserv import HistServAnalysis
+except ImportError as ie:
+    warn("Cannot import histserv, HaaS setup will not be available.")
 
 logger = logging.getLogger(__name__)
 

--- a/cms/src/intccms/analysis/processors.py
+++ b/cms/src/intccms/analysis/processors.py
@@ -35,8 +35,15 @@ from intccms.analysis.cms import CMSAnalysis
 try:
     from intccms.analysis.histserv import HistServAnalysis
 except ImportError as ie:
-    warn("Cannot import histserv, HaaS setup will not be available.")
-
+    warn(f"Cannot import histserv, HaaS setup will not be available: {ie}")
+    class HistServAnalysis:  # type: ignore[no-redef]
+        """Fallback placeholder when optional histserv dependency is unavailable."""
+        def __init__(self, *args, **kwargs):
+            raise ImportError(
+                "HistServAnalysis is unavailable, likely because " \
+                "histserv is not available"
+            ) from ie
+    
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
This is meant to rever accidently requiring `histserv` as a hard dependency. 

cc @oshadura reporting:

```
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
Cell In[6], line 6
      4 from intccms.metadata_extractor import DatasetMetadataManager
      5 from intccms.datasets import DatasetManager
----> 6 from intccms.analysis import run_processor_workflow, TwoHundredGbpsProcessor
      7 from intccms.utils.tools import get_branches_for_fraction, warm_xcache
      9 # roastcoffea metrics

File ~/integration-challenge/cms/src/intccms/analysis/__init__.py:7
      5 from .base import Analysis
      6 from .cms import CMSAnalysis
----> 7 from .processors import (
      8     HistLocalProcessor,
      9     HistServProcessor,
     10     SkimAndAnalyseProcessor,
     11     TwoHundredGbpsProcessor,
     12 )
     13 from .runner import run_processor_workflow
     16 __all__ = [
     17     "base",
     18     "cms",
   (...)
     25     "run_processor_workflow",
     26 ]

File ~/integration-challenge/cms/src/intccms/analysis/processors.py:20
     17 from roastcoffea import track_memory, track_metrics, track_time
     19 from intccms.analysis.cms import CMSAnalysis
---> 20 from intccms.analysis.histserv import HistServAnalysis
     21 from intccms.skimming.io.writers import get_writer
     22 from intccms.skimming.pipeline.stages import (
     23     build_column_list,
     24     extract_columns,
     25     save_events,
     26 )

File ~/integration-challenge/cms/src/intccms/analysis/histserv.py:11
      8 import cloudpickle
      9 import grpc
---> 11 from histserv import Client
     12 from intccms.analysis.cms import CMSAnalysis                                                                                                                                          
     13 from intccms.utils.functors import ObservableExecutor, SelectionExecutor                                                                                                              

ModuleNotFoundError: No module named 'histserv'
```
