### PR TITLE
feat/docs/fix: configurable kwargs, README polish, notebook import fixes

### DIFF
--- a/cms/README.md
+++ b/cms/README.md
@@ -3,23 +3,111 @@
 A coffea-based distributed analysis framework for the CMS Z' → tt̄ single-lepton search on Run 2 NanoAOD.
 
 **Contents**
-- [Setup](#setup)
-- [Configuration](#configuration)
-- [Datasets](#datasets)
-- [Dask client](#dask-client)
-- [Metadata generation](#metadata-generation)
-- [Handling bad files](#handling-bad-files)
-- [Workflow modes](#workflow-modes)
-- [Skimming](#skimming)
-- [The processor](#the-processor)
-- [Histogramming](#histogramming)
-- [Histogramming as a Service (HaaS)](#histogramming-as-a-service-haas)
-- [Corrections and systematics](#corrections-and-systematics)
-- [Metrics and profiling](#metrics-and-profiling)
-- [Inspecting inputs](#inspecting-inputs)
-- [Notebooks](#notebooks)
-- [Hacks](#hacks)
-- [Credentials](#credentials)
+
+<details><summary><a href="#setup">Setup</a></summary></details>
+<details><summary><a href="#notebooks">Notebooks</a></summary></details>
+<details><summary><a href="#configuration">Configuration</a></summary>
+
+- [How is the master config structured?](#how-is-the-master-config-structured)
+- [How do I modify config in a notebook?](#how-do-i-modify-config-in-a-notebook)
+
+</details>
+<details><summary><a href="#datasets">Datasets</a></summary>
+
+- [How are datasets defined?](#how-are-datasets-defined)
+- [How do I change the redirector?](#how-do-i-change-the-redirector)
+
+</details>
+<details><summary><a href="#dask-client">Dask client</a></summary>
+
+- [How do I connect to a Dask cluster?](#how-do-i-connect-to-a-dask-cluster)
+- [Which facilities are supported?](#which-facilities-are-supported)
+- [What options does `acquire_client` take?](#what-options-does-acquire_client-take)
+- [What are `WORKER_DEPENDENCIES` for?](#what-are-worker_dependencies-for)
+- [Where is the client used?](#where-is-the-client-used)
+- [Where do I add support for a new facility?](#where-do-i-add-support-for-a-new-facility)
+
+</details>
+<details><summary><a href="#metadata-generation">Metadata generation</a></summary>
+
+- [What is it and when do I need to re-run it?](#what-is-it-and-when-do-i-need-to-re-run-it)
+- [\[Advanced\] What are the components of the preprocessing workflow?](#advanced-what-are-the-components-of-the-preprocessing-workflow)
+
+</details>
+<details><summary><a href="#handling-bad-files">Handling bad files</a></summary>
+
+- [Skipping known bad files before processing](#skipping-known-bad-files-before-processing)
+- [Tolerating bad files during processing](#tolerating-bad-files-during-processing)
+- [Why do I get `ValueError: Empty list provided to reduction`?](#why-do-i-get-valueerror-empty-list-provided-to-reduction)
+
+</details>
+<details><summary><a href="#workflow-modes">Workflow modes</a></summary></details>
+<details><summary><a href="#skimming">Skimming</a></summary>
+
+- [How do I skim events?](#how-do-i-skim-events)
+- [What output formats are available?](#what-output-formats-are-available)
+- [How do I read back skimmed files?](#how-do-i-read-back-skimmed-files)
+
+</details>
+<details><summary><a href="#the-processor">The processor</a></summary>
+
+- [How is the analysis code organized?](#how-is-the-analysis-code-organized)
+- [Where does the processor live?](#where-does-the-processor-live)
+- [How do I write a custom processor?](#how-do-i-write-a-custom-processor)
+- [How do I pick which branches `TwoHundredGbpsProcessor` reads?](#how-do-i-pick-which-branches-twohundredgbpsprocessor-reads)
+- [How do I preload only the branches the processor accesses?](#how-do-i-preload-only-the-branches-the-processor-accesses)
+- [How do I post-process the processor output?](#how-do-i-post-process-the-processor-output)
+
+</details>
+<details><summary><a href="#histogramming">Histogramming</a></summary>
+
+- [How are histograms configured?](#how-are-histograms-configured)
+- [How are histograms initialized?](#how-are-histograms-initialized)
+- [Where does histogramming happen?](#where-does-histogramming-happen)
+- [Where are histograms saved?](#where-are-histograms-saved)
+
+</details>
+<details><summary><a href="#histogramming-as-a-service-haas">Histogramming as a Service (HaaS)</a></summary>
+
+- [When would I use this?](#when-would-i-use-this)
+- [How do I run it?](#how-do-i-run-it)
+- [Is there a local-histogramming counterpart?](#is-there-a-local-histogramming-counterpart)
+- [How does `HistServAnalysis` differ from `CMSAnalysis`?](#how-does-histservanalysis-differ-from-cmsanalysis)
+- [Where is the histserv server address set?](#where-is-the-histserv-server-address-set)
+- [How do I read back the final histograms?](#how-do-i-read-back-the-final-histograms)
+
+</details>
+<details><summary><a href="#corrections-and-systematics">Corrections and systematics</a></summary>
+
+- [How are corrections configured?](#how-are-corrections-configured)
+- [What corrections are implemented?](#what-corrections-are-implemented)
+- [How do I add a new correction?](#how-do-i-add-a-new-correction)
+
+</details>
+<details><summary><a href="#metrics-and-profiling">Metrics and profiling</a></summary>
+
+- [How do I collect performance metrics?](#how-do-i-collect-performance-metrics)
+- [How do I pre-warm xcache before a run?](#how-do-i-pre-warm-xcache-before-a-run)
+- [How do I profile worker activity?](#how-do-i-profile-worker-activity)
+
+</details>
+<details><summary><a href="#inspecting-inputs">Inspecting inputs</a></summary>
+
+- [How do I inspect NanoAOD input files?](#how-do-i-inspect-nanoaod-input-files)
+- [How do I inspect skimmed output files?](#how-do-i-inspect-skimmed-output-files)
+
+</details>
+<details><summary><a href="#hacks">Hacks</a></summary>
+
+- [Roastcoffea metrics can crash the 200gbps run at large read fractions](#roastcoffea-metrics-can-crash-the-200gbps-run-at-large-read-fractions)
+
+</details>
+<details><summary><a href="#credentials">Credentials</a></summary>
+
+- [VOMS proxy (CMS data access)](#voms-proxy-cms-data-access)
+- [S3 storage credentials](#s3-storage-credentials)
+
+</details>
 
 ## Setup
 
@@ -29,6 +117,22 @@ pixi run lab   # starts JupyterLab
 ```
 
 On an analysis facility (AF), use the notebooks directly &mdash; they install dependencies (`coffea`, `roastcoffea`, `omegaconf`) into the AF environment at runtime.
+
+## Notebooks
+
+| Notebook | Purpose |
+|----------|---------|
+| `full_run.ipynb` | Standard analysis workflow (metadata &rarr; processing &rarr; histograms) |
+| `full_run_with_metrics.ipynb` | Same workflow with roastcoffea performance dashboards |
+| `full_run_workflow_modes.ipynb` | Runs all four workflow modes (skim+analysis, analysis only, skim only, analysis on skims) with per-mode metrics comparison |
+| `full_run_skim_formats.ipynb` | Tests skimming output formats (Parquet/S3, TTree/XRootD, RNTuple/XRootD) with read-back verification |
+| `full_run_200gbps.ipynb` | I/O throughput benchmark with profiling |
+| `full_run_200gbps_preload_vs_not.ipynb` | Compares the 200gbps workflow with and without `preload=True` |
+| `full_run_200gbps_replicate_legacy.ipynb` | 200gbps run with the branch list hardcoded to the idap-200gbps legacy benchmark (via `prepare_branches_from_list`) for direct comparison |
+| `full_run_histserv.ipynb` | Standard workflow with histograms filled via HaaS (histserv) instead of reduce-aggregate |
+| `full_run_haas_or_not.ipynb` | Runs `HistServProcessor` and `HistLocalProcessor` back-to-back and compares metrics plus bin-by-bin histogram outputs |
+| `input_inspector.ipynb` | Inspect NanoAOD input files (event counts, branch sizes, compression) |
+| `skim_inspector.ipynb` | Inspect skimmed output files on XRootD or other remote storage |
 
 ## Configuration
 
@@ -690,22 +794,6 @@ The inspector produces rich tables (via `rich`) and matplotlib visualizations (e
 3. Runs the same distributed inspection and visualization pipeline
 
 To use it, edit the `SKIM_REDIRECTOR` and `SKIM_BASE` variables in the config cell to point at your skimmed file location.
-
-## Notebooks
-
-| Notebook | Purpose |
-|----------|---------|
-| `full_run.ipynb` | Standard analysis workflow (metadata &rarr; processing &rarr; histograms) |
-| `full_run_with_metrics.ipynb` | Same workflow with roastcoffea performance dashboards |
-| `full_run_workflow_modes.ipynb` | Runs all four workflow modes (skim+analysis, analysis only, skim only, analysis on skims) with per-mode metrics comparison |
-| `full_run_skim_formats.ipynb` | Tests skimming output formats (Parquet/S3, TTree/XRootD, RNTuple/XRootD) with read-back verification |
-| `full_run_200gbps.ipynb` | I/O throughput benchmark with profiling |
-| `full_run_200gbps_preload_vs_not.ipynb` | Compares the 200gbps workflow with and without `preload=True` |
-| `full_run_200gbps_replicate_legacy.ipynb` | 200gbps run with the branch list hardcoded to the idap-200gbps legacy benchmark (via `prepare_branches_from_list`) for direct comparison |
-| `full_run_histserv.ipynb` | Standard workflow with histograms filled via HaaS (histserv) instead of reduce-aggregate |
-| `full_run_haas_or_not.ipynb` | Runs `HistServProcessor` and `HistLocalProcessor` back-to-back and compares metrics plus bin-by-bin histogram outputs |
-| `input_inspector.ipynb` | Inspect NanoAOD input files (event counts, branch sizes, compression) |
-| `skim_inspector.ipynb` | Inspect skimmed output files on XRootD or other remote storage |
 
 ## Hacks
 

--- a/cms/README.md
+++ b/cms/README.md
@@ -6,6 +6,7 @@ A coffea-based distributed analysis framework for the CMS Z' → tt̄ single-lep
 - [Setup](#setup)
 - [Configuration](#configuration)
 - [Datasets](#datasets)
+- [Dask client](#dask-client)
 - [Metadata generation](#metadata-generation)
 - [Handling bad files](#handling-bad-files)
 - [Workflow modes](#workflow-modes)
@@ -108,6 +109,74 @@ Override per dataset after validation:
 for dataset in validated_config.datasets.datasets:
     dataset.redirector = "root://xcache/"
 ```
+
+## Dask client
+
+### How do I connect to a Dask cluster?
+
+Use `acquire_client` from `intccms.utils.dask_client`. It is a context manager that handles the facility-specific connection logic, registers a few useful worker plugins, and cleans up on exit:
+
+```python
+from intccms.utils.dask_client import acquire_client
+
+AF = "coffeacasa-condor"   # or coffeacasa-gateway, purdue-af-k8s, purdue-af-slurm
+AUTO_CLOSE_CLIENT = False
+WORKER_DEPENDENCIES = [COFFEA_PIP, "roastcoffea==0.1.2", "histserv==0.1.3"]
+
+with acquire_client(AF, close_after=AUTO_CLOSE_CLIENT, pip_packages=WORKER_DEPENDENCIES) as (client, cluster):
+    output, report = run_processor_workflow(..., executor=DaskExecutor(client=client))
+```
+
+It yields `(client, cluster)`. `cluster` is `None` for `coffeacasa-condor`, else it is the gateway cluster object.
+
+### Which facilities are supported?
+
+| `af` | How it connects |
+|------|-----------------|
+| `coffeacasa-condor` | Direct connect to `tls://localhost:8786` |
+| `coffeacasa-gateway` | Via `dask_gateway.Gateway()`, with X509 proxy and access token uploaded to workers |
+| `purdue-af-k8s` | Via `dask_gateway.Gateway()` against Purdue's k8s dask-gateway |
+| `purdue-af-slurm` | Via `dask_gateway.Gateway()` against Purdue's slurm dask-gateway |
+
+### What options does `acquire_client` take?
+
+| Argument | Default | What it controls |
+|----------|---------|------------------|
+| `af` | required | Facility identifier from the table above |
+| `num_workers` | `None` | Scales the gateway cluster to this many workers and waits for them via `client.wait_for_workers`. Ignored for `coffeacasa-condor` |
+| `close_after` | `False` | Close the client on context exit. Leave `False` when you want to reuse the client for follow-up work (pulling metrics, inspecting state) |
+| `pip_packages` | `None` | List of pip specifiers to install on every worker via `PipInstall` (coffea, roastcoffea, histserv, etc.). Gateway facilities reject git URLs here |
+| `propagate_aws_env` | `False` | Captures `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` from the client environment and sets them on workers. Needed for S3 skim output |
+| `profile_output_dir` | `None` | If set, dumps a Dask profile HTML to `<dir>/<timestamp>/dask_profile[_<suffix>].html` on context exit |
+| `profile_suffix` | `None` | Suffix appended to the profile filename, e.g. `"200gbps_preload"` |
+
+### What are `WORKER_DEPENDENCIES` for?
+
+Client-side installed packages are not automatically present on workers. `pip_packages` triggers `dask.distributed.PipInstall`, which pip-installs the listed specs on every worker before any task runs. The notebooks pin this in sync with the client-side installs:
+
+```python
+COFFEA_PIP = COFFEA_VERSION if "git" in COFFEA_VERSION else f"coffea=={COFFEA_VERSION}"
+WORKER_DEPENDENCIES = [COFFEA_PIP, "roastcoffea==0.1.2", "histserv==0.1.3"]
+```
+
+### Where is the client used?
+
+- **Metadata generation**: `metadata_generator.run(executor=DaskExecutor(client=client))` preprocesses files on the cluster.
+- **Processing**: `run_processor_workflow(..., executor=DaskExecutor(client=client))` fans out processor chunks.
+- **Metrics and profiling**: `MetricsCollector(client=client, ...)` tracks per-worker time and memory; `client.profile(...)` dumps a flamegraph.
+- **xcache pre-warm**: `warm_xcache(dataset_manager, client)` pre-pulls files into xcache from inside the cluster.
+
+### Where do I add support for a new facility?
+
+All facility wiring lives in `acquire_client()` in `src/intccms/utils/dask_client.py`. Add a new branch to the `if/elif` chain that:
+
+1. Builds the connection (direct `Client(...)` or `dask_gateway.Gateway(...)`).
+2. Optionally scales the cluster and calls `client.wait_for_workers(num_workers)`.
+3. Uploads credentials or registers worker callbacks if the site needs custom env setup (see the `coffeacasa-gateway` branch for a proxy + token example).
+
+Then add the new identifier to the `NotImplementedError` message in the final `else` branch, to the docstring's supported-facilities list, and to the table above.
+
+Shared setup (`PrintForwarder`, AWS env, `PipInstall`, `forward_logging`, optional profile dump) runs after your branch, so as long as you assign `client` and (if relevant) `cluster`, you get those plugins and the cleanup path for free.
 
 ## Metadata generation
 

--- a/cms/README.md
+++ b/cms/README.md
@@ -18,6 +18,7 @@ A coffea-based distributed analysis framework for the CMS Z' → tt̄ single-lep
 - [Metrics and profiling](#metrics-and-profiling)
 - [Inspecting inputs](#inspecting-inputs)
 - [Notebooks](#notebooks)
+- [Hacks](#hacks)
 - [Credentials](#credentials)
 
 ## Setup
@@ -675,6 +676,21 @@ To use it, edit the `SKIM_REDIRECTOR` and `SKIM_BASE` variables in the config ce
 | `full_run_haas_or_not.ipynb` | Runs `HistServProcessor` and `HistLocalProcessor` back-to-back and compares metrics plus bin-by-bin histogram outputs |
 | `input_inspector.ipynb` | Inspect NanoAOD input files (event counts, branch sizes, compression) |
 | `skim_inspector.ipynb` | Inspect skimmed output files on XRootD or other remote storage |
+
+## Hacks
+
+Things that should work but might break, which we are working on. Temporary workarounds until each is fixed upstream.
+
+### Roastcoffea metrics can crash the 200gbps run at large read fractions
+
+At large `TARGET_FRACTION` values in `full_run_200gbps.ipynb`, the run can crash while `MetricsCollector` pulls Dask span data back to the client. Fix pending in roastcoffea.
+
+To run without metrics, comment out:
+
+1. In the processor-run cell, the `with MetricsCollector(...) as collector:` block and every `collector.*` line (inside and after). De-indent the `run_processor_workflow(...)` call so it runs directly under `acquire_client`, and keep the `t0` / `t1` timers.
+2. The cells below "Performance Metrics" that reference `metrics`, `tracking_data`, or `span_metrics` ("Timeline Plots" and "Task and Processor Breakdown").
+
+The Dask profile via `profile_output_dir` on `acquire_client` is separate and still works.
 
 ## Credentials
 

--- a/cms/README.md
+++ b/cms/README.md
@@ -525,13 +525,24 @@ A third method, `_flush_fills()`, is called at the end of each chunk's `process(
 
 ### Where is the histserv server address set?
 
-Currently hardcoded in `src/intccms/analysis/histserv.py`:
+Pass `histserv_address=` when constructing `HistServProcessor`. If omitted, it falls back to `DEFAULT_HISTSERV_ADDRESS` defined in `src/intccms/analysis/processors.py`, which is currently:
 
-```python
-histserv_client = Client(address="...:8788")
+```
+oksana-2eshadura-40cern-2ech.dask-worker.cmsaf-dev.flatiron.hollandhpc.org:8788
 ```
 
-Edit this line to point at your own `histserv` instance.
+To point at your own histserv instance:
+
+```python
+from intccms.analysis import HistServProcessor
+
+processor = HistServProcessor(
+    config=validated_config,
+    output_manager=output_manager,
+    metadata_lookup=metadata_lookup,
+    histserv_address="my.histserv.host:8788",
+)
+```
 
 ### How do I read back the final histograms?
 

--- a/cms/README.md
+++ b/cms/README.md
@@ -425,12 +425,14 @@ The flow per chunk: `SkimAndAnalyseProcessor.process()` → skim selection → o
 
 ### Where does the processor live?
 
-`src/intccms/analysis/processors.py` has two processors:
+`src/intccms/analysis/processors.py` has four processors:
 
 - **`SkimAndAnalyseProcessor`**: The main processor. Per chunk, it: (1) applies skim selection, (2) saves filtered events to disk if enabled, (3) calls `CMSAnalysis.process()` for corrections and histogramming if enabled. All controlled by the config flags above.
 - **`TwoHundredGbpsProcessor`**: Minimal I/O benchmark. Reads and materializes configured branches, returns event count only.
+- **`HistServProcessor`**: HaaS variant. Applies the skim selection and fills histograms via a remote histserv server instead of coffea's reduce step. See [Histogramming as a Service (HaaS)](#histogramming-as-a-service-haas).
+- **`HistLocalProcessor`**: Local-reduce sibling of `HistServProcessor`, kept for HaaS-vs-local comparisons. See same section.
 
-Both are passed to `run_processor_workflow()` in `src/intccms/analysis/runner.py`.
+All four are passed to `run_processor_workflow()` in `src/intccms/analysis/runner.py`.
 
 ### How do I write a custom processor?
 

--- a/cms/README.md
+++ b/cms/README.md
@@ -694,6 +694,22 @@ The Dask profile via `profile_output_dir` on `acquire_client` is separate and st
 
 ## Credentials
 
+### VOMS proxy (CMS data access)
+
+To read CMS internal data over xrootd, initialize a VOMS proxy:
+
+```sh
+voms-proxy-init -voms cms -vomses /etc/vomses
+```
+
+This writes the proxy to `/tmp/x509up_u<uid>` and sets `X509_USER_PROXY` for the current shell.
+
+**Caveat for `coffeacasa-condor`**: the Dask cluster inherits the proxy location from the environment at the time it was started. If you run `voms-proxy-init` after the cluster is already up, the refreshed proxy does not reach workers, and any xrootd access from workers (reads or writes) will fail. Restart the Dask cluster after refreshing the proxy.
+
+**`coffeacasa-gateway`**: `acquire_client` uploads the proxy file from `/tmp/x509up_u<uid>` to every worker and points `X509_USER_PROXY` at the uploaded file via a worker callback, so a refreshed proxy is picked up on the next `acquire_client` context. No cluster restart needed.
+
+### S3 storage credentials
+
 Storage credentials (AWS keys for S3) go in an untracked `.env` file at the repo root (`cms/.env`). See `.env.example` for the expected variable names. Copy it and fill in your values:
 
 ```sh

--- a/cms/README.md
+++ b/cms/README.md
@@ -228,13 +228,32 @@ config["datasets"]["skip_files"] = [
 
 ### Tolerating bad files during processing
 
-Both the metadata extractor and the processor runner use coffea's `skipbadfiles` parameter to catch and skip files that fail at read time. The errors caught include `OSError`, `LZMAError`, `DecompressionError`, `DeserializationError`, and `AssertionError`.
+Both the metadata extractor and the processor runner use coffea's `skipbadfiles` parameter to catch and skip files that fail at read time. Pass `skipbadfiles=` to `DatasetMetadataManager.run(...)` (preprocessing) or to `run_processor_workflow(...)` (processing) to override. Accepts `False` (hard-fail on any bad file), `True` (coffea's built-in `OSError`-only behavior), or a tuple of exception types.
 
-This is configured in:
-- `src/intccms/metadata_extractor/extractor.py` (preprocessing)
-- `src/intccms/analysis/runner.py` (processing)
+The defaults are exposed as `DEFAULT_PREPROCESS_SKIPBADFILES` in `src/intccms/metadata_extractor/manager.py` and `DEFAULT_PROCESS_SKIPBADFILES` in `src/intccms/analysis/runner.py`, so users can extend them:
 
-To change which errors are tolerated, edit the `skipbadfiles` tuple in the `Runner(...)` constructor call in those files. Setting `skipbadfiles=False` disables this and makes any bad file a hard failure.
+```python
+from intccms.analysis.runner import DEFAULT_PROCESS_SKIPBADFILES, run_processor_workflow
+
+output, report = run_processor_workflow(
+    ...,
+    skipbadfiles=(*DEFAULT_PROCESS_SKIPBADFILES, ValueError),
+)
+```
+
+### Why do I get `ValueError: Empty list provided to reduction`?
+
+If many files hit the same exception type and that exception is in `skipbadfiles`, every affected chunk returns an empty accumulator. Coffea's reduce step then fails with a stack trace ending in:
+
+```
+File ".../coffea/processor/executor.py", line 253, in __call__
+    raise ValueError("Empty list provided to reduction")
+ValueError: Empty list provided to reduction
+```
+
+The root cause is that multiple task-graph nodes feeding into the reduce step are all producing empty accumulators, so the reduction has nothing to combine.
+
+To debug, narrow `skipbadfiles` so the underlying error surfaces. Drop suspect exception types from the tuple (e.g. remove `AssertionError` or `DeserializationError`) and re-run; the real failure will now raise from the worker and you can diagnose it.
 
 ## Workflow modes
 

--- a/cms/full_run_histserv.ipynb
+++ b/cms/full_run_histserv.ipynb
@@ -161,6 +161,7 @@
     "import copy\n",
     "import os\n",
     "import time\n",
+    "from collections import defaultdict\n",
     "\n",
     "from coffea.processor import DaskExecutor, IterativeExecutor\n",
     "from coffea.nanoevents import NanoAODSchema"

--- a/cms/full_run_skim_formats.ipynb
+++ b/cms/full_run_skim_formats.ipynb
@@ -492,7 +492,7 @@
    "outputs": [],
    "source": [
     "# Run processor workflow\n",
-    "from intccms.analysis.processor import SkimAndAnalyseProcessor\n",
+    "from intccms.analysis.processors import SkimAndAnalyseProcessor\n",
     "\n",
     "with acquire_client(AF, close_after=AUTO_CLOSE_CLIENT, pip_packages=WORKER_DEPENDENCIES, propagate_aws_env=PROPAGATE_AWS) as (client, cluster):\n",
     "    # Create processor instance for MetricsCollector\n",

--- a/cms/full_run_with_metrics.ipynb
+++ b/cms/full_run_with_metrics.ipynb
@@ -395,7 +395,7 @@
    "source": [
     "# Run processor workflow with roastcoffea metrics collection\n",
     "from roastcoffea import MetricsCollector\n",
-    "from intccms.analysis.processor import SkimAndAnalyseProcessor\n",
+    "from intccms.analysis.processors import SkimAndAnalyseProcessor\n",
     "\n",
     "with acquire_client(AF) as (client, cluster):\n",
     "    # Create processor instance for MetricsCollector\n",

--- a/cms/full_run_workflow_modes.ipynb
+++ b/cms/full_run_workflow_modes.ipynb
@@ -123,7 +123,7 @@
     "from intccms.metadata_extractor import DatasetMetadataManager\n",
     "from intccms.datasets import DatasetManager\n",
     "from intccms.analysis import run_processor_workflow\n",
-    "from intccms.analysis.processor import SkimAndAnalyseProcessor\n",
+    "from intccms.analysis.processors import SkimAndAnalyseProcessor\n",
     "\n",
     "from roastcoffea import MetricsCollector\n",
     "from roastcoffea.export.reporter import (\n",

--- a/cms/src/intccms/analysis/histserv.py
+++ b/cms/src/intccms/analysis/histserv.py
@@ -9,9 +9,10 @@ import cloudpickle
 import grpc
 
 from histserv import Client
-from intccms.analysis.cms import CMSAnalysis                                                                                                                                          
-from intccms.utils.functors import ObservableExecutor, SelectionExecutor                                                                                                              
-from intccms.utils.logging import setup_logging 
+from intccms.analysis.cms import CMSAnalysis
+from intccms.utils.functors import ObservableExecutor, SelectionExecutor
+from intccms.utils.logging import setup_logging
+from intccms.utils.output import OutputDirectoryManager
 
 # -----------------------------
 # Logging Configuration
@@ -29,6 +30,27 @@ class HistServAnalysis(CMSAnalysis):
     The processor should call process() method per-chunk.
     """
 
+    def __init__(
+        self,
+        config: dict[str, Any],
+        output_manager: OutputDirectoryManager,
+        histserv_address: str,
+    ) -> None:
+        """
+        Initialize HistServAnalysis.
+
+        Parameters
+        ----------
+        config : dict
+            Configuration dictionary (same as CMSAnalysis).
+        output_manager : OutputDirectoryManager
+            Centralized output directory manager.
+        histserv_address : str
+            Address (host:port) of the histserv server. Required.
+        """
+        self.histserv_address = histserv_address
+        super().__init__(config, output_manager)
+
     def _init_histograms(self) -> dict[str, dict[str, hist.Hist]]:
         """
         Initialize histograms for each analysis channel based on configuration.
@@ -38,7 +60,7 @@ class HistServAnalysis(CMSAnalysis):
         dict
             Dictionary of channel name to hist.Hist object.
         """
-        histserv_client = Client(address="oksana-2eshadura-40cern-2ech.dask-worker.cmsaf-dev.flatiron.hollandhpc.org:8788")
+        histserv_client = Client(address=self.histserv_address)
         histograms = defaultdict(dict)
         for channel in self.channels:
             channel_name = channel.name

--- a/cms/src/intccms/analysis/processors.py
+++ b/cms/src/intccms/analysis/processors.py
@@ -10,7 +10,7 @@ import logging
 import uuid
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 from warnings import warn
 
 import awkward as ak
@@ -500,6 +500,9 @@ class SkimAndAnalyseProcessor(ProcessorABC):
         return accumulator
 
 
+DEFAULT_HISTSERV_ADDRESS = "oksana-2eshadura-40cern-2ech.dask-worker.cmsaf-dev.flatiron.hollandhpc.org:8788"
+
+
 class HistServProcessor(ProcessorABC):
     """Simplified coffea processor that fills histograms via HaaS (histserv).
 
@@ -525,6 +528,7 @@ class HistServProcessor(ProcessorABC):
         config: Config,
         output_manager: OutputDirectoryManager,
         metadata_lookup: Dict[str, Dict[str, Any]],
+        histserv_address: Optional[str] = None,
     ):
         """Initialize HistServProcessor.
 
@@ -537,17 +541,24 @@ class HistServProcessor(ProcessorABC):
         metadata_lookup : Dict[str, Dict[str, Any]]
             Pre-built metadata lookup from NanoAODMetadataGenerator.build_metadata_lookup()
             Maps fileset_key -> {process, variation, xsec, nevts, is_data, dataset}
+        histserv_address : str, optional
+            Address (host:port) of the histserv server. If None, falls back to
+            DEFAULT_HISTSERV_ADDRESS.
         """
         self.config = config
         self.output_manager = output_manager
         self.metadata_lookup = metadata_lookup
         self.skim_config = config.preprocess.skimming
 
+        if histserv_address is None:
+            histserv_address = DEFAULT_HISTSERV_ADDRESS
+
         # Always create HistServAnalysis instance
         # The run_analysis flag controls whether we execute its methods
         self.analysis = HistServAnalysis(
             config=config,
             output_manager=output_manager,
+            histserv_address=histserv_address,
         )
 
         logger.info(

--- a/cms/src/intccms/analysis/runner.py
+++ b/cms/src/intccms/analysis/runner.py
@@ -7,7 +7,7 @@ path (for iterating on statistical models without re-processing).
 
 import logging
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 from lzma import LZMAError
 from cramjam import DecompressionError
 from collections import defaultdict
@@ -31,6 +31,10 @@ from intccms.schema import Config
 logger = logging.getLogger(__name__)
 
 
+DEFAULT_PROCESS_SKIPBADFILES: Tuple[Type[BaseException], ...] = (
+    OSError, LZMAError, UprootMissTreeError, DeserializationError, DecompressionError, AssertionError,
+)
+
 
 def run_processor_workflow(
     config: Config,
@@ -43,6 +47,7 @@ def run_processor_workflow(
     chunksize: Optional[int] = None,
     preload: bool = False,
     post: Optional[Callable] = None,
+    skipbadfiles: Union[bool, Tuple[Type[BaseException], ...]] = DEFAULT_PROCESS_SKIPBADFILES,
 ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     """Execute processor workflow or load saved histograms.
 
@@ -83,6 +88,10 @@ def run_processor_workflow(
         If not None, this is a post-processing function that runs over the output from
         the coffea processor. The function must accept the processor and its output (in order)
         and return and updated output dictionary/accumlator.
+    skipbadfiles : bool or tuple of exception types, optional
+        Forwarded to coffea's Runner. Defaults to DEFAULT_PROCESS_SKIPBADFILES.
+        Pass False to hard-fail on any bad file, True for coffea's built-in
+        OSError-only behavior, or a custom tuple of exception types.
 
     Returns
     -------
@@ -202,7 +211,7 @@ def run_processor_workflow(
             schema=schema,
             chunksize=chunksize,
             savemetrics=True,
-            skipbadfiles=(OSError, LZMAError, UprootMissTreeError, DeserializationError, DecompressionError, AssertionError),
+            skipbadfiles=skipbadfiles,
             **runner_kwargs,
         )
 

--- a/cms/src/intccms/metadata_extractor/extractor.py
+++ b/cms/src/intccms/metadata_extractor/extractor.py
@@ -5,15 +5,13 @@ to extract WorkItems from ROOT files.
 """
 
 import logging
-from typing import Any, Dict, List
-from lzma import LZMAError
-from cramjam import DecompressionError
+from typing import Any, Dict, List, Tuple, Type, Union
 
 from coffea.processor.executor import WorkItem
-from coffea.processor.executor import UprootMissTreeError
 from coffea import processor
 from coffea.nanoevents import NanoAODSchema
-from uproot import DeserializationError
+
+from intccms.metadata_extractor.manager import DEFAULT_PREPROCESS_SKIPBADFILES
 
 
 logger = logging.getLogger(__name__)
@@ -32,7 +30,13 @@ class CoffeaMetadataExtractor:
         The coffea processor runner configured for preprocessing
     """
 
-    def __init__(self, executor: Any = None, schema: Any = None, chunksize: int = 100_000):
+    def __init__(
+        self,
+        executor: Any = None,
+        schema: Any = None,
+        chunksize: int = 100_000,
+        skipbadfiles: Union[bool, Tuple[Type[BaseException], ...]] = DEFAULT_PREPROCESS_SKIPBADFILES,
+    ):
         """
         Initialize CoffeaMetadataExtractor with configurable executor.
 
@@ -46,6 +50,10 @@ class CoffeaMetadataExtractor:
             If None, uses NanoAODSchema by default.
         chunksize : int, optional
             Number of events per chunk for WorkItem splitting, default 100_000
+        skipbadfiles : bool or tuple of exception types, optional
+            Forwarded to coffea's Runner. Defaults to DEFAULT_PREPROCESS_SKIPBADFILES.
+            Pass False to hard-fail on any bad file, True for coffea's built-in
+            OSError-only behavior, or a custom tuple of exception types.
         """
 
 
@@ -61,7 +69,7 @@ class CoffeaMetadataExtractor:
             schema=schema,
             savemetrics=True,
             chunksize=chunksize,
-            skipbadfiles=(OSError, LZMAError, UprootMissTreeError, DeserializationError,DecompressionError)
+            skipbadfiles=skipbadfiles,
         )
 
         logger.debug(

--- a/cms/src/intccms/metadata_extractor/manager.py
+++ b/cms/src/intccms/metadata_extractor/manager.py
@@ -8,12 +8,20 @@ and core functions.
 import json
 import logging
 import sys
+from lzma import LZMAError
 from pathlib import Path
-from typing import Any, Dict, List, Optional, TypedDict, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, TypedDict, Union
 
+from cramjam import DecompressionError
 from rich.pretty import pretty_repr
-from coffea.processor.executor import WorkItem
+from coffea.processor.executor import WorkItem, UprootMissTreeError
 from coffea.nanoevents import NanoAODSchema
+from uproot import DeserializationError
+
+
+DEFAULT_PREPROCESS_SKIPBADFILES: Tuple[Type[BaseException], ...] = (
+    OSError, LZMAError, UprootMissTreeError, DeserializationError, DecompressionError,
+)
 
 
 from intccms.datasets import DatasetManager, Dataset
@@ -151,6 +159,7 @@ class DatasetMetadataManager:
         executor: Any = None,
         schema: Any = None,
         identifiers: Optional[Union[int, List[int]]] = None,
+        skipbadfiles: Union[bool, Tuple[Type[BaseException], ...]] = DEFAULT_PREPROCESS_SKIPBADFILES,
     ) -> None:
         """
         Generate or load metadata based on config settings.
@@ -167,6 +176,9 @@ class DatasetMetadataManager:
             Schema for parsing ROOT files. Defaults to NanoAODSchema.
         identifiers : int or list of ints, optional
             Specific listing file IDs to process. Only used when generating metadata.
+        skipbadfiles : bool or tuple of exception types, optional
+            Forwarded to CoffeaMetadataExtractor and coffea's Runner. Defaults to
+            DEFAULT_PREPROCESS_SKIPBADFILES.
 
         Raises
         ------
@@ -181,7 +193,7 @@ class DatasetMetadataManager:
                     "executor is required when run_metadata_generation=True. "
                     "Pass a DaskExecutor or FuturesExecutor."
                 )
-            self._generate_metadata(executor, schema, identifiers)
+            self._generate_metadata(executor, schema, identifiers, skipbadfiles)
         else:
             self._load_existing_metadata()
 
@@ -190,6 +202,7 @@ class DatasetMetadataManager:
         executor: Any,
         schema: Any,
         identifiers: Optional[Union[int, List[int]]],
+        skipbadfiles: Union[bool, Tuple[Type[BaseException], ...]] = DEFAULT_PREPROCESS_SKIPBADFILES,
     ) -> None:
         """
         Generate metadata workflow.
@@ -202,13 +215,18 @@ class DatasetMetadataManager:
             Schema for parsing ROOT files. If None, uses NanoAODSchema.
         identifiers : int or list of ints, optional
             Listing file IDs to process
+        skipbadfiles : bool or tuple of exception types, optional
+            Forwarded to CoffeaMetadataExtractor. Defaults to
+            DEFAULT_PREPROCESS_SKIPBADFILES.
         """
         logger.info("Starting metadata generation workflow...")
 
         # Create extractor on-demand with provided executor
         if schema is None:
             schema = NanoAODSchema
-        metadata_extractor = CoffeaMetadataExtractor(executor, schema, self.chunksize)
+        metadata_extractor = CoffeaMetadataExtractor(
+            executor, schema, self.chunksize, skipbadfiles=skipbadfiles,
+        )
 
         # Step 1: Build and save fileset and Dataset objects
         self.fileset, self.datasets = self.fileset_builder.build_fileset(


### PR DESCRIPTION
## Summary

Two new public kwargs and a batch of README/notebook cleanups.

**New kwargs**
- `skipbadfiles=` on `DatasetMetadataManager.run` and `run_processor_workflow`. Defaults preserve current behavior; module-level constants `DEFAULT_PREPROCESS_SKIPBADFILES` (in `metadata_extractor/manager.py`) and `DEFAULT_PROCESS_SKIPBADFILES` (in `analysis/runner.py`) are exposed so users can extend rather than rewrite the tuple.
- `histserv_address=` on `HistServProcessor`. Defaults to `None`; resolved to `DEFAULT_HISTSERV_ADDRESS` in `analysis/processors.py`. The hardcoded address inside `histserv.py` is gone.

**Notebook fixes**
- `full_run_histserv.ipynb`: add missing `from collections import defaultdict` used by the post function.
- `full_run_workflow_modes.ipynb`, `full_run_with_metrics.ipynb`, `full_run_skim_formats.ipynb`: fix `intccms.analysis.processor` typo (module is `processors`, plural).

**Docs**
- New Dask client section covering `acquire_client`, supported AFs, options, worker dependencies, and how to add a new facility.
- New Hacks section with a workaround for the roastcoffea metrics crash on large 200gbps fractions.
- New VOMS proxy subsection in Credentials, including the condor cluster-restart caveat.
- New FAQ for `ValueError: Empty list provided to reduction` (over-permissive `skipbadfiles`).
- Notebooks moved to the top of the README; TOC made collapsible per section.
- "Where does the processor live?" now lists all four processors instead of two.