### PR TITLE
feat: add metrics inspector submodule

### DIFF
--- a/cms/src/intccms/metrics/__init__.py
+++ b/cms/src/intccms/metrics/__init__.py
@@ -1,0 +1,10 @@
+"""Metrics and inspection tools.
+
+Runtime metrics collection (processor timing, throughput, worker tracking)
+is handled by roastcoffea. This package provides input data inspection
+utilities for characterizing ROOT files before processing.
+"""
+
+from . import inspector
+
+__all__ = ["inspector"]

--- a/cms/src/intccms/metrics/inspector/__init__.py
+++ b/cms/src/intccms/metrics/inspector/__init__.py
@@ -1,0 +1,67 @@
+"""File inspection for input data characterization.
+
+This module provides tools for extracting metadata from ROOT files using
+distributed processing with Dask.
+
+Example Usage
+-------------
+>>> from dask.distributed import Client
+>>> from intccms.metrics.inspector import inspect_dataset_distributed, aggregate_statistics
+>>>
+>>> client = Client()
+>>> results, errors = inspect_dataset_distributed(client, file_list)
+>>> print(f"Success: {errors['successful']}/{errors['total_files']} files")
+>>> stats = aggregate_statistics(results)
+>>> print(f"Total events: {stats['total_events']:,}")
+"""
+
+from intccms.metrics.inspector.core import (
+    inspect_file,
+    inspect_dataset_distributed,
+    get_total_events_distributed,
+    format_error_summary,
+)
+from intccms.metrics.inspector.aggregator import (
+    aggregate_statistics,
+    get_top_branches,
+    group_by_dataset,
+    compute_dataset_statistics,
+    compute_compression_stats,
+)
+from intccms.metrics.inspector.integration import (
+    extract_files_from_dataset_manager,
+    get_dataset_file_counts,
+)
+from intccms.metrics.inspector.format import (
+    format_overall_stats_table,
+    format_branch_stats_table,
+    format_dataset_stats_table,
+    format_compression_stats_table,
+)
+from intccms.metrics.inspector import plot, rucio
+
+__all__ = [
+    # Core inspection
+    "inspect_file",
+    "inspect_dataset_distributed",
+    "get_total_events_distributed",
+    "format_error_summary",
+    # Aggregation
+    "aggregate_statistics",
+    "get_top_branches",
+    "group_by_dataset",
+    "compute_dataset_statistics",
+    "compute_compression_stats",
+    # Integration
+    "extract_files_from_dataset_manager",
+    "get_dataset_file_counts",
+    # Formatting
+    "format_overall_stats_table",
+    "format_branch_stats_table",
+    "format_dataset_stats_table",
+    "format_compression_stats_table",
+    # Plotting
+    "plot",
+    # Rucio helper module
+    "rucio",
+]

--- a/cms/src/intccms/metrics/inspector/aggregator.py
+++ b/cms/src/intccms/metrics/inspector/aggregator.py
@@ -1,0 +1,414 @@
+"""Aggregation and statistics for file inspection results."""
+
+from collections import defaultdict
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+from intccms.metrics.inspector.rucio import build_size_lookup  # type: ignore
+
+
+def _branch_count(record: Dict) -> int:
+    """Return the number of branches described in a result record."""
+    branches = record.get("branches", {})
+    if isinstance(branches, dict):
+        return len(branches)
+    if isinstance(branches, (list, tuple)):
+        return len(branches)
+    return 0
+
+
+def _lfn_from_path(filepath: str) -> str:
+    """Normalize a filepath to the underlying logical file name."""
+    if filepath.startswith("root://"):
+        stripped = filepath[len("root://") :]
+        if "/" not in stripped:
+            return filepath
+        _, rest = stripped.split("/", 1)
+        return "/" + rest.lstrip("/")
+    return filepath
+
+
+def aggregate_statistics(
+    results: List[Dict],
+    size_summary: Optional[Dict] = None,
+) -> Dict:
+    """Compute aggregate statistics from file inspection results.
+
+    Parameters
+    ----------
+    results : List[dict]
+        List of file metadata dicts from :func:`inspect_file`.
+    size_summary : dict, optional
+        Optional size information produced by :func:`inspector.rucio.fetch_file_sizes`.
+        When supplied, byte-related metrics are derived from this summary. Without it,
+        byte-centric numbers default to zero (useful when analysing remote files
+        without local access).
+
+    Returns
+    -------
+    stats : dict
+        Dictionary containing aggregate statistics
+
+    Examples
+    --------
+    >>> stats = aggregate_statistics(results)
+    >>> print(f"Total events: {stats['total_events']:,}")
+    >>>
+    >>> size_summary = fetch_file_sizes(dataset_manager, processes=["signal"])
+    >>> stats_with_sizes = aggregate_statistics(results, size_summary=size_summary)
+    """
+    event_counts = [r["num_events"] for r in results]
+    total_events = sum(event_counts)
+
+    # Unique branches across all files
+    all_branches = set()
+    for record in results:
+        all_branches.update(record["branches"].keys())
+
+    if event_counts:
+        hist, bin_edges = np.histogram(event_counts, bins=10)
+    else:
+        hist, bin_edges = np.array([]), np.array([])
+
+    size_lookup = build_size_lookup(size_summary) if size_summary else {}
+    size_values = [entry["bytes"] for entry in size_summary.get("files", [])] if size_summary else []
+    total_size_bytes = size_summary.get("total_bytes", 0) if size_summary else 0
+    total_files_with_sizes = size_summary.get("total_files", 0) if size_summary else 0
+
+    bytes_sum = 0
+    events_with_size = 0
+    event_branch_pairs = 0
+
+    if size_lookup:
+        for record in results:
+            filepath = record["filepath"]
+            bytes_value = size_lookup.get(filepath)
+            if bytes_value is None:
+                bytes_value = size_lookup.get(_lfn_from_path(filepath))
+
+            if bytes_value:
+                bytes_sum += bytes_value
+                if record["num_events"] > 0:
+                    events_with_size += record["num_events"]
+                    branch_count = _branch_count(record)
+                    if branch_count > 0:
+                        event_branch_pairs += record["num_events"] * branch_count
+
+    stats = {
+        "total_files": len(results),
+        "total_events": total_events,
+        "total_size_bytes": total_size_bytes,
+        "avg_events_per_file": np.mean(event_counts) if event_counts else 0,
+        "std_events_per_file": np.std(event_counts) if event_counts else 0,
+        "median_events_per_file": np.median(event_counts) if event_counts else 0,
+        "p90_events_per_file": np.percentile(event_counts, 90) if event_counts else 0,
+        "avg_file_size_bytes": (
+            total_size_bytes / total_files_with_sizes if total_files_with_sizes else 0
+        ),
+        "median_file_size_bytes": np.median(size_values) if size_values else 0,
+        "p90_file_size_bytes": np.percentile(size_values, 90) if size_values else 0,
+        "total_branches": len(all_branches),
+        "avg_bytes_per_event": (
+            bytes_sum / events_with_size if events_with_size else 0
+        ),
+        "avg_bytes_per_event_per_branch": (
+            bytes_sum / event_branch_pairs if event_branch_pairs else 0
+        ),
+        "event_histogram": {
+            "bins": bin_edges.tolist(),
+            "counts": hist.tolist(),
+        },
+    }
+
+    return stats
+
+
+def get_top_branches(results: List[Dict], top_n: int = 20) -> List[Tuple[str, int, float]]:
+    """Find the largest branches across all files.
+
+    Parameters
+    ----------
+    results : List[dict]
+        List of file metadata dicts
+    top_n : int
+        Number of top branches to return
+
+    Returns
+    -------
+    top_branches : List[Tuple[str, int, float]]
+        List of (branch_name, total_bytes, avg_compression_ratio) tuples
+
+    Examples
+    --------
+    >>> top = get_top_branches(results, top_n=10)
+    >>> for name, size, ratio in top[:5]:
+    ...     print(f"{name}: {size/1024:.1f} KB (ratio: {ratio:.2f}x)")
+    """
+    # Aggregate branch sizes across all files
+    branch_totals = defaultdict(int)
+    branch_compression = defaultdict(list)
+
+    for result in results:
+        for branch_name, info in result["branches"].items():
+            # info is tuple: (num_bytes, compressed_bytes, uncompressed_bytes)
+            num_bytes, compressed_bytes, uncompressed_bytes = info
+            branch_totals[branch_name] += num_bytes
+
+            # Track compression ratios if available
+            if compressed_bytes > 0 and uncompressed_bytes > 0:
+                ratio = uncompressed_bytes / compressed_bytes
+                branch_compression[branch_name].append(ratio)
+
+    # Compute average compression ratio per branch
+    branch_avg_compression = {}
+    for branch_name, ratios in branch_compression.items():
+        branch_avg_compression[branch_name] = np.mean(ratios) if ratios else 1.0
+
+    # Sort by total size
+    sorted_branches = sorted(branch_totals.items(), key=lambda x: x[1], reverse=True)
+
+    # Return top N with compression info
+    top_branches = [
+        (name, size, branch_avg_compression.get(name, 1.0))
+        for name, size in sorted_branches[:top_n]
+    ]
+
+    return top_branches
+
+
+def group_by_dataset(
+    results: List[Dict], dataset_map: Optional[Dict[str, str]] = None
+) -> Dict[str, List[Dict]]:
+    """Group file results by dataset name.
+
+    Parameters
+    ----------
+    results : List[dict]
+        List of file metadata dicts
+    dataset_map : Dict[str, str], optional
+        Mapping from filepath to dataset name
+        If None, uses "dataset" key from results if available
+
+    Returns
+    -------
+    grouped : Dict[str, List[dict]]
+        Dictionary mapping dataset name to list of file metadata
+
+    Examples
+    --------
+    >>> # With dataset info already in results
+    >>> grouped = group_by_dataset(results)
+    >>>
+    >>> # Or provide explicit mapping
+    >>> dataset_map = {filepath: "ttbar_semilep" for filepath in file_list}
+    >>> grouped = group_by_dataset(results, dataset_map)
+    """
+    grouped = defaultdict(list)
+
+    for result in results:
+        # Try to get dataset name from multiple sources
+        if dataset_map and result["filepath"] in dataset_map:
+            dataset = dataset_map[result["filepath"]]
+        elif "dataset" in result:
+            dataset = result["dataset"]
+        else:
+            dataset = "unknown"
+
+        grouped[dataset].append(result)
+
+    return dict(grouped)
+
+
+def compute_dataset_statistics(
+    grouped: Dict[str, List[Dict]],
+    size_summary: Optional[Dict] = None,
+) -> Dict[str, Dict]:
+    """Compute per-dataset statistics.
+
+    Parameters
+    ----------
+    grouped : Dict[str, List[dict]]
+        Grouped results from group_by_dataset()
+    size_summary : dict, optional
+        Optional size summary produced by :func:`inspector.rucio.fetch_file_sizes`.
+
+    Returns
+    -------
+    dataset_stats : Dict[str, dict]
+        Dictionary mapping dataset name to statistics dict
+
+    Examples
+    --------
+    >>> grouped = group_by_dataset(results, dataset_map)
+    >>> stats = compute_dataset_statistics(grouped)
+    >>> for dataset, ds_stats in stats.items():
+    ...     print(f"{dataset}: {ds_stats['total_events']:,} events")
+    >>>
+    >>> size_summary = fetch_file_sizes(dataset_manager, processes=["signal"])
+    >>> stats = compute_dataset_statistics(grouped, size_summary=size_summary)
+    """
+    dataset_stats: Dict[str, Dict] = {}
+    size_lookup = build_size_lookup(size_summary) if size_summary else {}
+    dataset_summary = size_summary.get("datasets", {}) if size_summary else {}
+
+    for dataset_name, files in grouped.items():
+        event_counts = [f["num_events"] for f in files]
+        bytes_values = []
+        for record in files:
+            filepath = record["filepath"]
+            bytes_value = size_lookup.get(filepath)
+            if bytes_value is None:
+                bytes_value = size_lookup.get(_lfn_from_path(filepath))
+            if bytes_value:
+                bytes_values.append(bytes_value)
+
+        dataset_info = dataset_summary.get(dataset_name, {})
+        total_size_bytes = dataset_info.get("total_bytes")
+        if total_size_bytes is None:
+            total_size_bytes = sum(bytes_values)
+
+        num_files_with_sizes = dataset_info.get("num_files")
+        if num_files_with_sizes is None:
+            num_files_with_sizes = len(bytes_values)
+
+        events_with_size = sum(
+            record["num_events"]
+            for record in files
+            if size_lookup.get(record["filepath"])
+            or size_lookup.get(_lfn_from_path(record["filepath"]))
+        )
+        event_branch_pairs = sum(
+            record["num_events"] * _branch_count(record)
+            for record in files
+            if (
+                size_lookup.get(record["filepath"])
+                or size_lookup.get(_lfn_from_path(record["filepath"]))
+            )
+            and record["num_events"] > 0
+            and _branch_count(record) > 0
+        )
+
+        dataset_stats[dataset_name] = {
+            "num_files": len(files),
+            "total_events": sum(event_counts),
+            "total_size_bytes": total_size_bytes,
+            "avg_events_per_file": np.mean(event_counts) if event_counts else 0,
+            "avg_file_size_bytes": (
+                total_size_bytes / num_files_with_sizes if num_files_with_sizes else 0
+            ),
+            "median_file_size_bytes": np.median(bytes_values) if bytes_values else 0,
+            "bytes_per_event": (
+                total_size_bytes / events_with_size if events_with_size else 0
+            ),
+            "bytes_per_event_per_branch": (
+                total_size_bytes / event_branch_pairs if event_branch_pairs else 0
+            ),
+        }
+
+    return dataset_stats
+
+
+def compute_compression_stats(results: List[Dict]) -> Dict:
+    """Compute compression statistics from inspection results.
+
+    Parameters
+    ----------
+    results : List[dict]
+        List of file metadata dicts
+
+    Returns
+    -------
+    compression_stats : dict
+        Dictionary containing compression statistics
+
+    Examples
+    --------
+    >>> stats = compute_compression_stats(results)
+    >>> print(f"Avg compression: {stats['avg_tree_compression_ratio']:.2f}x")
+    """
+    tree_ratios = []
+    total_compressed = 0
+    total_uncompressed = 0
+    files_with_compression = 0
+
+    for result in results:
+        comp = result.get("tree_compressed_bytes", 0)
+        uncomp = result.get("tree_uncompressed_bytes", 0)
+
+        if comp > 0 and uncomp > 0:
+            tree_ratios.append(uncomp / comp)
+            total_compressed += comp
+            total_uncompressed += uncomp
+            files_with_compression += 1
+
+    return {
+        "avg_tree_compression_ratio": np.mean(tree_ratios) if tree_ratios else 0,
+        "median_tree_compression_ratio": np.median(tree_ratios) if tree_ratios else 0,
+        "files_with_compression": files_with_compression,
+        "total_compressed_bytes": total_compressed,
+        "total_uncompressed_bytes": total_uncompressed,
+        "overall_compression_ratio": (
+            total_uncompressed / total_compressed if total_compressed > 0 else 0
+        ),
+    }
+
+
+def compute_branch_statistics(results: List[Dict]) -> Dict:
+    """Compute branch-level statistics for distribution plots.
+
+    Aggregates branch sizes across all files and collects compression ratios
+    for all branches across all files.
+
+    Parameters
+    ----------
+    results : List[dict]
+        List of file metadata dicts from inspection
+
+    Returns
+    -------
+    branch_stats : dict
+        Dictionary containing:
+        - branch_sizes: List of total branch sizes (summed across files)
+        - compression_ratios: List of compression ratios (one per branch per file)
+        - branch_names: List of unique branch names
+        - num_branches: Number of unique branches
+
+    Examples
+    --------
+    >>> stats = compute_branch_statistics(results)
+    >>> # Use for box plot of branch sizes
+    >>> plt.boxplot(stats['branch_sizes'])
+    >>> # Use for box plot of compression ratios
+    >>> plt.boxplot(stats['compression_ratios'])
+    """
+    # Aggregate branch sizes across all files
+    branch_totals = defaultdict(int)
+    compression_ratios = []
+    all_branch_names = set()
+
+    for result in results:
+        for branch_name, info in result["branches"].items():
+            all_branch_names.add(branch_name)
+
+            # info is tuple: (num_bytes, compressed_bytes, uncompressed_bytes)
+            num_bytes, compressed_bytes, uncompressed_bytes = info
+
+            # Aggregate total size for this branch
+            branch_totals[branch_name] += num_bytes
+
+            # Collect compression ratio if available
+            if compressed_bytes > 0 and uncompressed_bytes > 0:
+                ratio = uncompressed_bytes / compressed_bytes
+                compression_ratios.append(ratio)
+
+    # Convert to lists for plotting
+    branch_sizes = list(branch_totals.values())
+    branch_names = list(all_branch_names)
+
+    return {
+        "branch_sizes": branch_sizes,
+        "compression_ratios": compression_ratios,
+        "branch_names": branch_names,
+        "num_branches": len(branch_names),
+    }

--- a/cms/src/intccms/metrics/inspector/core.py
+++ b/cms/src/intccms/metrics/inspector/core.py
@@ -1,0 +1,421 @@
+"""Distributed file inspection for input data characterization.
+
+This module provides functions to extract metadata from ROOT files in parallel
+using Dask, enabling fast characterization of large datasets.
+"""
+
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple, Union
+
+import dask.bag as db
+import uproot
+
+try:
+    from coffea.dataset_tools import rucio_utils  # type: ignore
+except ImportError:  # pragma: no cover
+    rucio_utils = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+_RUCIO_SCOPE = "cms"
+_RUCIO_CLIENT = None
+
+
+def _is_remote_path(filepath: str) -> bool:
+    return filepath.startswith("root://")
+
+
+def _strip_root_redirector(filepath: str) -> str:
+    """
+    Remove the XRootD redirector from a remote path, returning the logical file name.
+    """
+    stripped = filepath[len("root://") :]
+    if "/" not in stripped:
+        return filepath
+    _, rest = stripped.split("/", 1)
+    rest = rest.lstrip("/")
+    return f"/{rest}"
+
+
+def _get_rucio_client():
+    global _RUCIO_CLIENT
+
+    if rucio_utils is None:
+        return None
+
+    if _RUCIO_CLIENT is None:
+        try:
+            _RUCIO_CLIENT = rucio_utils.get_rucio_client()
+        except Exception as exc:  # pragma: no cover - depends on env
+            logger.warning("Failed to create Rucio client: %s", exc)
+            _RUCIO_CLIENT = None
+    return _RUCIO_CLIENT
+
+
+def _get_remote_file_size(filepath: str, rucio_client=None) -> int:
+    client = rucio_client or _get_rucio_client()
+    if client is None:
+        return 0
+
+    lfn = _strip_root_redirector(filepath)
+    name_candidates = []
+
+    lfn_no_slash = lfn.lstrip("/")
+    if lfn_no_slash:
+        name_candidates.append(lfn_no_slash)
+    if lfn.startswith("/"):
+        name_candidates.append(lfn)
+
+    for name in name_candidates:
+        try:
+            meta = client.get_file_meta(scope=_RUCIO_SCOPE, name=name)
+        except Exception:
+            continue
+        if meta and "bytes" in meta and meta["bytes"]:
+            try:
+                return int(meta["bytes"])
+            except (TypeError, ValueError):
+                continue
+    return 0
+
+
+def inspect_file(filepath: str, max_branches: Optional[int] = None) -> Dict:
+    """Extract all metadata from a single ROOT file.
+
+    Memory-efficient implementation: Branch data is stored as compact tuples
+    (num_bytes, compressed_bytes, uncompressed_bytes) instead of dicts,
+    reducing memory usage by ~60% for large-scale inspections.
+
+    Parameters
+    ----------
+    filepath : str
+        Path to ROOT file (local or XRootD URL)
+    max_branches : int, optional
+        Limit inspection to first N branches (for faster processing on large files)
+
+    Returns
+    -------
+    metadata : dict
+        Dictionary containing:
+        - filepath: Original file path
+        - file_size_bytes: File size on disk
+        - num_events: Number of events in tree
+        - num_branches: Number of branches
+        - total_branch_bytes: Sum of all branch sizes
+        - tree_compressed_bytes: Tree-level compressed size
+        - tree_uncompressed_bytes: Tree-level uncompressed size
+        - branches: Dict mapping branch name to (num_bytes, compressed, uncompressed) tuples
+
+    Examples
+    --------
+    >>> metadata = inspect_file("file.root")
+    >>> print(f"Events: {metadata['num_events']:,}")
+    >>> print(f"Size: {metadata['file_size_bytes'] / 1024**3:.2f} GB")
+    >>>
+    >>> # Access branch data
+    >>> for name, (num_bytes, compressed, uncompressed) in metadata['branches'].items():
+    ...     print(f"{name}: {num_bytes/1024:.1f} KB")
+    """
+    try:
+        with uproot.open(filepath) as f:
+            tree = f["Events"]
+
+            # Get all branch info - use compact tuple format to reduce memory
+            # Format: (num_bytes, compressed_bytes, uncompressed_bytes)
+            branches = {}
+            for branch_name in tree.keys()[:max_branches]:
+                branch = tree[branch_name]
+
+                # Get sizes
+                # - num_bytes: Always works (on-disk size including ROOT overhead)
+                # - compressed/uncompressed: Work on production files, may be 0 on small test files
+                num_bytes = branch.num_bytes if hasattr(branch, "num_bytes") else 0
+                compressed = (
+                    branch.compressed_bytes if hasattr(branch, "compressed_bytes") else 0
+                )
+                uncompressed = (
+                    branch.uncompressed_bytes if hasattr(branch, "uncompressed_bytes") else 0
+                )
+
+                # Store as tuple for memory efficiency: (num_bytes, compressed, uncompressed)
+                branches[branch_name] = (int(num_bytes), int(compressed), int(uncompressed))
+
+            # Compute totals - branches are tuples (num_bytes, compressed, uncompressed)
+            total_branch_bytes = sum(b[0] for b in branches.values())
+
+            # Get tree-level compression info if available
+            tree_compressed = tree.compressed_bytes if hasattr(tree, "compressed_bytes") else 0
+            tree_uncompressed = (
+                tree.uncompressed_bytes if hasattr(tree, "uncompressed_bytes") else 0
+            )
+
+            # Get file size (handle both local and remote)
+            if _is_remote_path(filepath):
+                file_size_bytes = _get_remote_file_size(filepath)
+            else:
+                file_size_bytes = Path(filepath).stat().st_size
+
+            result = {
+                "filepath": str(filepath),  # Ensure string
+                "file_size_bytes": int(file_size_bytes),  # Ensure int
+                "num_events": int(tree.num_entries),  # Ensure int
+                "num_branches": int(len(branches)),  # Ensure int
+                "total_branch_bytes": int(total_branch_bytes),  # Ensure int
+                "tree_compressed_bytes": int(tree_compressed),  # Ensure int
+                "tree_uncompressed_bytes": int(tree_uncompressed),  # Ensure int
+                "branches": branches,  # Dict of dicts with int values
+            }
+
+            # Add num_branches_sampled if max_branches was used
+            if max_branches is not None:
+                result["num_branches_sampled"] = int(len(branches))
+                # Update num_branches to total count
+                result["num_branches"] = int(len(tree.keys()))
+
+            return result
+    except Exception as e:
+        # Return dict with error info for error tracking
+        # Use simple types to ensure Dask can serialize/deserialize
+        try:
+            error_type = type(e).__name__
+            error_message = str(e)
+        except Exception:
+            # Fallback if even getting error info fails
+            error_type = "UnknownError"
+            error_message = "Could not extract error details"
+
+        return {
+                "filepath": str(filepath),  # Ensure string
+                "file_size_bytes": -1,
+                "num_events": -1,
+                "num_branches": -1,
+                "total_branch_bytes": -1,
+                "tree_compressed_bytes": -1,
+                "tree_uncompressed_bytes": -1,
+                "branches": {},
+                "error_type": error_type,
+                "error_message": error_message,
+        }
+
+
+def inspect_dataset_distributed(
+    client,
+    filepaths: List[str],
+    max_branches: Optional[int] = None,
+) -> Tuple[List[Dict], Dict]:
+    """Inspect multiple files in parallel using Dask with robust error handling.
+
+    Memory-efficient for large-scale inspections:
+    - Branch data stored as compact tuples (~60% memory reduction vs dicts)
+    - Streams results from workers without holding all in memory
+    - Example: 13K files × 1000 branches = ~1.3 GB (vs 3.3 GB with dict format)
+
+    Parameters
+    ----------
+    client : dask.distributed.Client
+        Dask distributed client
+    filepaths : List[str]
+        List of file paths to inspect
+    max_branches : int, optional
+        Limit branch info to first N branches (faster for large files)
+        If None, inspect all branches
+
+    Returns
+    -------
+    results : List[dict]
+        List of metadata dicts for successfully inspected files
+    error_summary : dict
+        Summary of failures with keys:
+        - total_files: Total files attempted
+        - successful: Number of successful inspections
+        - failed: Number of failed inspections
+        - failures: List of failure dicts with filepath, error_type, error_message
+
+    Examples
+    --------
+    >>> from dask.distributed import Client
+    >>> client = Client()
+    >>> results, errors = inspect_dataset_distributed(client, file_list)
+    >>> print(f"Success: {errors['successful']}/{errors['total_files']}")
+    >>> if errors['failures']:
+    ...     for failure in errors['failures']:
+    ...         print(f"Failed: {failure['filepath']} - {failure['error_type']}")
+    """
+    # Create tuples of (filepath, max_branches) for each file
+    file_args = [(fp, max_branches) for fp in filepaths]
+
+    # Use reasonable number of partitions (not one per file!)
+    # Aim for ~100 files per partition, or at least use fewer partitions
+    n_partitions = min(len(filepaths), max(1, len(filepaths) // 5))
+
+    # Use Dask bag to process files - compute directly without persist
+    # This streams results from workers to client without holding all in memory
+    bag = db.from_sequence(file_args, npartitions=len(filepaths)) #TODO:: configure
+
+    try:
+        # Compute all results - Dask streams from workers as they complete
+        raw_results = bag.map(lambda args: inspect_file(*args)).compute()
+    except Exception as e:
+        # If Dask itself fails, fail gracefully
+        error_summary = {
+            "total_files": len(filepaths),
+            "successful": 0,
+            "failed": len(filepaths),
+            "failures": [{
+                "filepath": "ALL FILES",
+                "error_type": type(e).__name__,
+                "error_message": f"Dask compute failed: {str(e)}",
+            }],
+        }
+        return [], error_summary
+
+    # Separate successes from failures on client side
+    successes = []
+    failures = []
+
+    for result in raw_results:
+        if "error_type" in result:
+            # This is an error
+            failures.append({
+                "filepath": result["filepath"],
+                "error_type": result["error_type"],
+                "error_message": result["error_message"],
+            })
+        else:
+            # This is a success
+            successes.append(result)
+
+    # Build error summary
+    error_summary = {
+        "total_files": len(filepaths),
+        "successful": len(successes),
+        "failed": len(failures),
+        "failures": failures,
+    }
+
+    return successes, error_summary
+
+
+def format_error_summary(error_summary: Dict) -> str:
+    """Format error summary as a readable table.
+
+    Parameters
+    ----------
+    error_summary : dict
+        Error summary from inspect_dataset_distributed with keys:
+        - total_files: Total files attempted
+        - successful: Number of successful inspections
+        - failed: Number of failed inspections
+        - failures: List of failure dicts
+
+    Returns
+    -------
+    formatted : str
+        Formatted string representation with summary and failure table
+
+    Examples
+    --------
+    >>> results, errors = inspect_dataset_distributed(client, file_list)
+    >>> print(format_error_summary(errors))
+    === Inspection Summary ===
+    Total files:   100
+    Successful:     98
+    Failed:          2
+    Success rate: 98.0%
+
+    === Failures ===
+    File                              Error Type        Error Message
+    ──────────────────────────────────────────────────────────────────────────
+    /path/to/file1.root              FileNotFoundError No such file or directory
+    /path/to/file2.root              OSError           Connection timeout
+    """
+    lines = []
+
+    # Summary section
+    lines.append("=== Inspection Summary ===")
+    lines.append(f"Total files:   {error_summary['total_files']:>4}")
+    lines.append(f"Successful:    {error_summary['successful']:>4}")
+    lines.append(f"Failed:        {error_summary['failed']:>4}")
+
+    if error_summary['total_files'] > 0:
+        success_rate = 100 * error_summary['successful'] / error_summary['total_files']
+        lines.append(f"Success rate: {success_rate:>5.1f}%")
+
+    # Failures table if any
+    if error_summary['failed'] > 0:
+        lines.append("")
+        lines.append("=== Failures ===")
+
+        # Calculate column widths
+        max_file_len = max(len(f['filepath']) for f in error_summary['failures'])
+        max_type_len = max(len(f['error_type']) for f in error_summary['failures'])
+        max_msg_len = max(len(f['error_message']) for f in error_summary['failures'])
+
+        # Ensure minimum widths
+        file_width = max(max_file_len, len("File"))
+        type_width = max(max_type_len, len("Error Type"))
+        msg_width = max(max_msg_len, len("Error Message"))
+
+        # Limit message width for readability
+        msg_width = min(msg_width, 60)
+
+        # Header
+        header = f"{'File':<{file_width}}  {'Error Type':<{type_width}}  {'Error Message':<{msg_width}}"
+        lines.append(header)
+        lines.append("─" * len(header))
+
+        # Failure rows
+        for failure in error_summary['failures']:
+            filepath = failure['filepath']
+            error_type = failure['error_type']
+            error_msg = failure['error_message']
+
+            # Truncate long messages
+            if len(error_msg) > msg_width:
+                error_msg = error_msg[:msg_width-3] + "..."
+
+            row = f"{filepath:<{file_width}}  {error_type:<{type_width}}  {error_msg:<{msg_width}}"
+            lines.append(row)
+
+    return "\n".join(lines)
+
+
+def get_total_events_distributed(client, filepaths: List[str]) -> int:
+    """Get total event count across files using Dask fold.
+
+    Fast aggregation for when you only need event counts.
+
+    Parameters
+    ----------
+    client : dask.distributed.Client
+        Dask distributed client
+    filepaths : List[str]
+        List of file paths
+
+    Returns
+    -------
+    total_events : int
+        Sum of events across all files
+
+    Examples
+    --------
+    >>> total = get_total_events_distributed(client, file_list)
+    >>> print(f"Total events: {total:,}")
+    """
+
+    def get_entries(filepath: str) -> int:
+        """Get number of entries from file."""
+        try:
+            with uproot.open(filepath) as f:
+                return f["Events"].num_entries
+        except Exception:
+            return 0
+
+    # Use fold to aggregate
+    bag = db.from_sequence(filepaths)
+    futures = bag.map(get_entries)
+    task = futures.fold(lambda x, y: x + y, split_every=4)
+    total_events = task.compute()
+
+    return total_events

--- a/cms/src/intccms/metrics/inspector/format.py
+++ b/cms/src/intccms/metrics/inspector/format.py
@@ -1,0 +1,214 @@
+"""Rich formatting for inspection statistics display."""
+
+from typing import Dict
+from rich.table import Table
+from rich.console import Console
+
+
+def _format_bytes(value: float) -> str:
+    """Format byte quantity with appropriate unit."""
+    if value is None or value <= 0:
+        return "0 B"
+
+    units = ["B", "KB", "MB", "GB", "TB"]
+    magnitude = 0
+    while value >= 1024 and magnitude < len(units) - 1:
+        value /= 1024
+        magnitude += 1
+    return f"{value:.2f} {units[magnitude]}"
+
+
+def format_overall_stats_table(stats: Dict) -> Table:
+    """Format overall statistics as a rich table.
+
+    Parameters
+    ----------
+    stats : dict
+        Statistics from aggregate_statistics()
+
+    Returns
+    -------
+    table : rich.table.Table
+        Formatted rich table
+
+    Examples
+    --------
+    >>> from rich.console import Console
+    >>> console = Console(force_jupyter=False)
+    >>> table = format_overall_stats_table(stats)
+    >>> console.print(table)
+    """
+    table = Table(title="Overall Statistics", show_header=True, header_style="bold cyan")
+    table.add_column("Metric", style="cyan", no_wrap=True)
+    table.add_column("Value", justify="right", style="green")
+
+    # File and event counts
+    table.add_row("Total Files", f"{stats['total_files']:,}")
+    table.add_row("Total Events", f"{stats['total_events']:,}")
+    table.add_row("Total Size", f"{stats['total_size_bytes'] / 1024**3:.2f} GB")
+
+    table.add_section()
+
+    # Events per file
+    table.add_row("Avg Events/File", f"{stats['avg_events_per_file']:,.0f}")
+    table.add_row("Median Events/File", f"{stats['median_events_per_file']:,.0f}")
+    table.add_row("P90 Events/File", f"{stats['p90_events_per_file']:,.0f}")
+
+    table.add_section()
+
+    # File sizes
+    table.add_row("Avg File Size", f"{stats['avg_file_size_bytes'] / 1024**3:.2f} GB")
+    table.add_row("Median File Size", f"{stats['median_file_size_bytes'] / 1024**3:.2f} GB")
+
+    table.add_section()
+
+    table.add_row("Avg Bytes/Event", _format_bytes(stats.get('avg_bytes_per_event')))
+    table.add_row("Avg Bytes/Event/Branch", _format_bytes(stats.get('avg_bytes_per_event_per_branch')))
+
+    table.add_section()
+
+    # Branch info
+    table.add_row("Total Branches", f"{stats['total_branches']}")
+
+    return table
+
+
+def format_branch_stats_table(branch_stats: Dict) -> Table:
+    """Format branch statistics as a rich table.
+
+    Parameters
+    ----------
+    branch_stats : dict
+        Statistics from compute_branch_statistics()
+
+    Returns
+    -------
+    table : rich.table.Table
+        Formatted rich table
+
+    Examples
+    --------
+    >>> from rich.console import Console
+    >>> console = Console(force_jupyter=False)
+    >>> table = format_branch_stats_table(branch_stats)
+    >>> console.print(table)
+    """
+    import numpy as np
+
+    table = Table(title="Branch Statistics", show_header=True, header_style="bold magenta")
+    table.add_column("Metric", style="magenta", no_wrap=True)
+    table.add_column("Value", justify="right", style="yellow")
+
+    # Number of branches
+    table.add_row("Number of Branches", f"{branch_stats['num_branches']:,}")
+
+    table.add_section()
+
+    # Branch sizes (convert to MB)
+    sizes_mb = [s / 1024 / 1024 for s in branch_stats['branch_sizes']]
+    table.add_row("Median Branch Size", f"{np.median(sizes_mb):.2f} MB")
+    table.add_row("Mean Branch Size", f"{np.mean(sizes_mb):.2f} MB")
+    table.add_row("Max Branch Size", f"{max(sizes_mb):.2f} MB")
+
+    table.add_section()
+
+    # Compression ratios
+    if branch_stats['compression_ratios']:
+        table.add_row("Median Compression", f"{np.median(branch_stats['compression_ratios']):.2f}x")
+        table.add_row("Mean Compression", f"{np.mean(branch_stats['compression_ratios']):.2f}x")
+    else:
+        table.add_row("Compression Data", "Not Available")
+
+    return table
+
+
+def format_dataset_stats_table(dataset_stats: Dict[str, Dict]) -> Table:
+    """Format per-dataset statistics as a rich table.
+
+    Parameters
+    ----------
+    dataset_stats : Dict[str, dict]
+        Statistics from compute_dataset_statistics()
+
+    Returns
+    -------
+    table : rich.table.Table
+        Formatted rich table
+
+    Examples
+    --------
+    >>> from rich.console import Console
+    >>> console = Console(force_jupyter=False)
+    >>> table = format_dataset_stats_table(dataset_stats)
+    >>> console.print(table)
+    """
+    table = Table(title="Per-Dataset Statistics", show_header=True, header_style="bold blue")
+    table.add_column("Dataset", style="blue", no_wrap=True)
+    table.add_column("Files", justify="right", style="cyan")
+    table.add_column("Total Events", justify="right", style="green")
+    table.add_column("Avg Events/File", justify="right", style="yellow")
+    table.add_column("Total Size", justify="right", style="magenta")
+    table.add_column("Avg File Size", justify="right", style="red")
+    table.add_column("Bytes/Event", justify="right", style="yellow")
+    table.add_column("Bytes/Event/Branch", justify="right", style="yellow")
+
+    for dataset_name, stats in dataset_stats.items():
+        table.add_row(
+            dataset_name,
+            f"{stats['num_files']:,}",
+            f"{stats['total_events']:,}",
+            f"{stats['avg_events_per_file']:,.0f}",
+            f"{stats['total_size_bytes'] / 1024**3:.2f} GB",
+            f"{stats['avg_file_size_bytes'] / 1024**3:.2f} GB",
+            _format_bytes(stats.get('bytes_per_event')),
+            _format_bytes(stats.get('bytes_per_event_per_branch')),
+        )
+
+    return table
+
+
+def format_compression_stats_table(comp_stats: Dict) -> Table:
+    """Format compression statistics as a rich table.
+
+    Parameters
+    ----------
+    comp_stats : dict
+        Statistics from compute_compression_stats()
+
+    Returns
+    -------
+    table : rich.table.Table
+        Formatted rich table
+
+    Examples
+    --------
+    >>> from rich.console import Console
+    >>> console = Console(force_jupyter=False)
+    >>> table = format_compression_stats_table(comp_stats)
+    >>> console.print(table)
+    """
+    table = Table(title="Compression Statistics", show_header=True, header_style="bold red")
+    table.add_column("Metric", style="red", no_wrap=True)
+    table.add_column("Value", justify="right", style="yellow")
+
+    # Files with compression data
+    table.add_row("Files with Compression", f"{comp_stats['files_with_compression']:,}")
+
+    table.add_section()
+
+    # Tree-level compression
+    table.add_row("Avg Tree Compression", f"{comp_stats['avg_tree_compression_ratio']:.2f}x")
+    table.add_row("Median Tree Compression", f"{comp_stats['median_tree_compression_ratio']:.2f}x")
+    table.add_row("Overall Compression", f"{comp_stats['overall_compression_ratio']:.2f}x")
+
+    table.add_section()
+
+    # Sizes
+    table.add_row("Total Compressed", f"{comp_stats['total_compressed_bytes'] / 1024**3:.2f} GB")
+    table.add_row("Total Uncompressed", f"{comp_stats['total_uncompressed_bytes'] / 1024**3:.2f} GB")
+    table.add_row(
+        "Space Savings",
+        f"{(comp_stats['total_uncompressed_bytes'] - comp_stats['total_compressed_bytes']) / 1024**3:.2f} GB"
+    )
+
+    return table

--- a/cms/src/intccms/metrics/inspector/integration.py
+++ b/cms/src/intccms/metrics/inspector/integration.py
@@ -1,0 +1,138 @@
+"""Integration with DatasetManager - extract files for inspection.
+
+This module bridges DatasetManager (which has dataset configurations and file listings)
+to the inspector module. It uses existing infrastructure from metadata_extractor.
+
+IMPORTANT: This does NOT require metadata preprocessing - it works directly with
+the raw dataset configuration.
+"""
+
+from typing import Dict, List, Optional, Tuple
+
+from intccms.datasets import DatasetManager
+from intccms.metadata_extractor.io import collect_file_paths
+from intccms.utils.filters import should_process
+
+
+def extract_files_from_dataset_manager(
+    dataset_manager: DatasetManager,
+    processes: Optional[List[str]] = None,
+    identifiers: Optional[List[int]] = None,
+    max_files_per_process: Optional[int] = None,
+) -> Tuple[List[str], Dict[str, str]]:
+    """Extract file paths from DatasetManager for inspection.
+
+    Reads .txt files from dataset directories to get actual ROOT file paths.
+    Uses the same infrastructure as metadata_extractor.
+
+    Parameters
+    ----------
+    dataset_manager : DatasetManager
+        Dataset manager with configuration
+    processes : List[str], optional
+        List of process names to inspect (e.g., ["signal", "ttbar_semilep"])
+        If None, inspects all processes
+    identifiers : List[int], optional
+        Specific listing file IDs to process (e.g., [0, 1] reads 0.txt, 1.txt)
+        If None, reads all .txt files
+    max_files_per_process : int, optional
+        Limit files per process (useful for quick sampling)
+
+    Returns
+    -------
+    file_list : List[str]
+        List of ROOT file paths (XRootD URLs or local paths)
+    dataset_map : Dict[str, str]
+        Mapping from filepath to dataset/process name
+
+    Examples
+    --------
+    >>> from intccms.datasets import DatasetManager
+    >>> dm = DatasetManager(config)
+    >>>
+    >>> # Get all files
+    >>> files, dataset_map = extract_files_from_dataset_manager(dm)
+    >>>
+    >>> # Or just specific processes
+    >>> files, dataset_map = extract_files_from_dataset_manager(
+    ...     dm, processes=["signal", "ttbar_semilep"]
+    ... )
+    >>>
+    >>> # Or sample first 10 files per process
+    >>> files, dataset_map = extract_files_from_dataset_manager(
+    ...     dm, max_files_per_process=10
+    ... )
+    >>>
+    >>> # Or specific listing files
+    >>> files, dataset_map = extract_files_from_dataset_manager(
+    ...     dm, identifiers=[0, 1]  # Only reads 0.txt and 1.txt
+    ... )
+    """
+    file_list = []
+    dataset_map = {}
+
+    # Iterate over each configured process
+    for process_name in dataset_manager.list_processes():
+        # Check if processes filter is configured
+        if not should_process(process_name, processes):
+            continue
+
+        try:
+            # Get configuration for this process
+            directories = dataset_manager.get_dataset_directories(process_name)
+            redirector = dataset_manager.get_redirector(process_name)
+
+            # Collect files from all directories for this process
+            process_files = []
+            for directory in directories:
+                # Use existing collect_file_paths infrastructure
+                files = collect_file_paths(directory, identifiers, redirector)
+                process_files.extend(files)
+
+            # Apply max_files limit if specified
+            if max_files_per_process is not None:
+                process_files = process_files[:max_files_per_process]
+
+            # Add to file_list and dataset_map
+            for filepath in process_files:
+                file_list.append(filepath)
+                dataset_map[filepath] = process_name
+
+        except (KeyError, FileNotFoundError):
+            # Process not found or no files found, skip
+            continue
+
+    return file_list, dataset_map
+
+
+def get_dataset_file_counts(dataset_manager: DatasetManager) -> Dict[str, int]:
+    """Get file count per dataset without full inspection.
+
+    Quick summary of how many files per process.
+
+    Parameters
+    ----------
+    dataset_manager : DatasetManager
+        Dataset manager with configuration
+
+    Returns
+    -------
+    file_counts : Dict[str, int]
+        Mapping from process name to number of files
+
+    Examples
+    --------
+    >>> counts = get_dataset_file_counts(dm)
+    >>> for dataset, count in counts.items():
+    ...     print(f"{dataset}: {count} files")
+    """
+    file_list, dataset_map = extract_files_from_dataset_manager(dataset_manager)
+
+    # Count files per dataset
+    from collections import defaultdict
+    counts = defaultdict(int)
+
+    for filepath, dataset in dataset_map.items():
+        counts[dataset] += 1
+
+    return dict(counts)

--- a/cms/src/intccms/metrics/inspector/plot.py
+++ b/cms/src/intccms/metrics/inspector/plot.py
@@ -1,0 +1,664 @@
+"""Visualization tools for input file inspection results."""
+
+from typing import Dict, List, Optional
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.ticker import ScalarFormatter
+
+from intccms.metrics.inspector.aggregator import compute_branch_statistics, group_by_dataset
+
+
+def _apply_modern_style(ax):
+    """Apply modern plotting style to axes.
+
+    Applies consistent styling:
+    - Internal tick marks on all sides
+    - Minor ticks enabled
+    - Light grid
+    - Removes top/right spines for cleaner look
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes
+        Axes object to style
+    """
+    # Internal tick marks on all sides
+    ax.tick_params(
+        direction="in",
+        which="both",
+        top=True,
+        right=True,
+        labelsize=10,
+    )
+
+    # Enable minor ticks
+    ax.minorticks_on()
+
+    # Light grid
+    ax.grid(True, alpha=0.2, linewidth=0.5)
+
+    # Remove top and right spines for cleaner look
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+
+
+def _apply_scientific_notation(ax, axis="x", threshold=1e4):
+    """Apply scientific notation with LaTeX when tick magnitudes are large."""
+    axis_obj = ax.xaxis if axis == "x" else ax.yaxis
+    ticks = axis_obj.get_ticklocs()
+    finite_ticks = [abs(t) for t in ticks if np.isfinite(t)]
+    if not finite_ticks:
+        return
+    if max(finite_ticks) < threshold:
+        return
+
+    formatter = ScalarFormatter(useMathText=True)
+    formatter.set_powerlimits((-3, 3))
+    axis_obj.set_major_formatter(formatter)
+    axis_obj.get_offset_text().set_fontsize(10)
+
+
+def _label_with_units(ax, axis: str, base_label: str, unit: Optional[str] = None):
+    """Append unit text to an axis label if provided."""
+    label = base_label.strip()
+    if unit:
+        label = f"{label} ({unit})"
+
+    if axis == "x":
+        ax.set_xlabel(label, fontsize=12)
+    else:
+        ax.set_ylabel(label, fontsize=12)
+
+
+def plot_event_distribution(
+    results: List[Dict],
+    title: str = "Event Distribution Across Files",
+    figsize: tuple = (10, 6),
+    save_path: Optional[str] = None,
+):
+    """Plot histogram of events per file.
+
+    Parameters
+    ----------
+    results : List[dict]
+        File inspection results
+    title : str
+        Plot title
+    figsize : tuple
+        Figure size (width, height)
+    save_path : str, optional
+        Path to save figure (if None, just displays)
+
+    Examples
+    --------
+    >>> plot_event_distribution(results)
+    >>> plot_event_distribution(results, save_path="events_distribution.png")
+    """
+    event_counts = [r["num_events"] for r in results]
+
+    fig, ax = plt.subplots(figsize=figsize)
+
+    ax.hist(event_counts, bins=30, edgecolor="none", alpha=0.6, color="steelblue")
+    _label_with_units(ax, "x", "Events per File", "events")
+    _label_with_units(ax, "y", "Number of Files")
+    ax.set_title(title, fontsize=14, fontweight='bold')
+
+    # Apply modern style
+    _apply_modern_style(ax)
+    _apply_scientific_notation(ax, axis="x")
+
+    # Add stats text
+    stats_text = f"Files: {len(event_counts)}\n"
+    stats_text += f"Mean: {np.mean(event_counts):,.0f}\n"
+    stats_text += f"Median: {np.median(event_counts):,.0f}\n"
+    stats_text += f"Total: {sum(event_counts):,.0f}"
+
+    ax.text(0.98, 0.97, stats_text,
+            transform=ax.transAxes,
+            verticalalignment='top',
+            horizontalalignment='right',
+            bbox=dict(boxstyle='round', facecolor='wheat', alpha=0.5),
+            fontsize=10)
+
+    plt.tight_layout()
+
+    if save_path:
+        plt.savefig(save_path, dpi=300, bbox_inches='tight')
+        print(f"Saved to {save_path}")
+
+    return fig, ax
+
+
+def plot_dataset_comparison(
+    dataset_stats: Dict[str, Dict],
+    title: str = "Dataset Comparison",
+    figsize: tuple = (12, 6),
+    save_path: Optional[str] = None,
+):
+    """Plot comparison of datasets (files and events).
+
+    Parameters
+    ----------
+    dataset_stats : Dict[str, dict]
+        Per-dataset statistics from compute_dataset_statistics()
+    title : str
+        Plot title
+    figsize : tuple
+        Figure size
+    save_path : str, optional
+        Path to save figure
+
+    Examples
+    --------
+    >>> plot_dataset_comparison(dataset_stats)
+    """
+    datasets = list(dataset_stats.keys())
+    num_files = [stats["num_files"] for stats in dataset_stats.values()]
+    total_events = [stats["total_events"] for stats in dataset_stats.values()]
+
+    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=figsize)
+
+    # Files per dataset
+    ax1.barh(datasets, num_files, color="steelblue", edgecolor="none", alpha=0.6)
+    _label_with_units(ax1, "x", "Number of Files")
+    ax1.set_title("Files per Dataset", fontsize=13, fontweight='bold')
+
+    # Add values on bars
+    for i, v in enumerate(num_files):
+        ax1.text(v, i, f" {v:,}", va='center', fontsize=9)
+
+    # Apply modern style
+    _apply_modern_style(ax1)
+
+    # Events per dataset
+    ax2.barh(datasets, total_events, color="coral", edgecolor="none", alpha=0.6)
+    _label_with_units(ax2, "x", "Total Events", "events")
+    ax2.set_title("Events per Dataset", fontsize=13, fontweight='bold')
+
+    # Add values on bars
+    for i, v in enumerate(total_events):
+        ax2.text(v, i, f" {v:,}", va='center', fontsize=9)
+
+    # Apply modern style
+    _apply_modern_style(ax2)
+    _apply_scientific_notation(ax2, axis="x")
+
+    fig.suptitle(title, fontsize=14, fontweight='bold', y=1.02)
+    plt.tight_layout()
+
+    if save_path:
+        plt.savefig(save_path, dpi=300, bbox_inches='tight')
+        print(f"Saved to {save_path}")
+
+    return fig, (ax1, ax2)
+
+
+def plot_events_per_file_by_dataset(
+    dataset_stats: Dict[str, Dict],
+    title: str = "Events per File by Dataset",
+    figsize: tuple = (10, 6),
+    save_path: Optional[str] = None,
+):
+    """Plot events/file ratio comparison across datasets.
+
+    Parameters
+    ----------
+    dataset_stats : Dict[str, dict]
+        Per-dataset statistics from compute_dataset_statistics()
+    title : str
+        Plot title
+    figsize : tuple
+        Figure size
+    save_path : str, optional
+        Path to save figure
+
+    Examples
+    --------
+    >>> plot_events_per_file_by_dataset(dataset_stats)
+    """
+    datasets = list(dataset_stats.keys())
+    events_per_file = [stats["avg_events_per_file"] for stats in dataset_stats.values()]
+
+    fig, ax = plt.subplots(figsize=figsize)
+
+    # Horizontal bar chart showing events/file ratio
+    ax.barh(datasets, events_per_file, color="mediumseagreen", edgecolor="none", alpha=0.6)
+
+    _label_with_units(ax, "x", "Average Events per File", "events")
+    ax.set_title(title, fontsize=14, fontweight='bold')
+
+    # Add values on bars
+    for i, v in enumerate(events_per_file):
+        ax.text(v, i, f" {v:,.0f}", va='center', fontsize=9)
+
+    # Apply modern style
+    _apply_modern_style(ax)
+    _apply_scientific_notation(ax, axis="x")
+
+    plt.tight_layout()
+
+    if save_path:
+        plt.savefig(save_path, dpi=300, bbox_inches='tight')
+        print(f"Saved to {save_path}")
+
+    return fig, ax
+
+
+def plot_branch_size_distribution(
+    results: List[Dict],
+    title: str = "Branch Size Distribution",
+    figsize: tuple = (10, 6),
+    save_path: Optional[str] = None,
+):
+    """Plot box plot of branch sizes across all branches.
+
+    Parameters
+    ----------
+    results : List[dict]
+        File inspection results
+    title : str
+        Plot title
+    figsize : tuple
+        Figure size
+    save_path : str, optional
+        Path to save figure
+
+    Examples
+    --------
+    >>> plot_branch_size_distribution(results)
+    """
+    # Compute branch statistics
+    stats = compute_branch_statistics(results)
+    sizes_mb = [s / 1024 / 1024 for s in stats["branch_sizes"]]  # Convert to MB
+
+    fig, ax = plt.subplots(figsize=figsize)
+
+    # Create box plot with 5th-95th percentile whiskers
+    bp = ax.boxplot(
+        sizes_mb,
+        orientation='vertical',
+        patch_artist=True,
+        widths=0.5,
+        whis=[5, 95],
+    )
+    bp['boxes'][0].set_facecolor('mediumseagreen')
+    bp['boxes'][0].set_alpha(0.6)
+
+    _label_with_units(ax, "y", "Branch Size", "MB")
+    ax.set_title(title, fontsize=14, fontweight='bold')
+    ax.set_xticks([])
+
+    # Apply modern style
+    _apply_modern_style(ax)
+
+    # Add stats text
+    stats_text = f"Total branches: {stats['num_branches']}\n"
+    stats_text += f"Median: {np.median(sizes_mb):.2f} MB\n"
+    stats_text += f"Mean: {np.mean(sizes_mb):.2f} MB"
+
+    ax.text(0.98, 0.97, stats_text,
+            transform=ax.transAxes,
+            verticalalignment='top',
+            horizontalalignment='right',
+            bbox=dict(boxstyle='round', facecolor='wheat', alpha=0.5),
+            fontsize=10)
+
+    plt.tight_layout()
+
+    if save_path:
+        plt.savefig(save_path, dpi=300, bbox_inches='tight')
+        print(f"Saved to {save_path}")
+
+    return fig, ax
+
+
+def plot_branch_compression_distribution(
+    results: List[Dict],
+    title: str = "Branch Compression Ratio Distribution",
+    figsize: tuple = (10, 6),
+    save_path: Optional[str] = None,
+):
+    """Plot box plot of compression ratios across all branches.
+
+    Parameters
+    ----------
+    results : List[dict]
+        File inspection results
+    title : str
+        Plot title
+    figsize : tuple
+        Figure size
+    save_path : str, optional
+        Path to save figure
+
+    Examples
+    --------
+    >>> plot_branch_compression_distribution(results)
+    """
+    # Compute branch statistics
+    stats = compute_branch_statistics(results)
+    compression_ratios = stats["compression_ratios"]
+
+    if not compression_ratios:
+        print("No compression data available")
+        return None, None
+
+    fig, ax = plt.subplots(figsize=figsize)
+
+    # Create box plot with 5th-95th percentile whiskers
+    bp = ax.boxplot(
+        compression_ratios,
+        orientation='vertical',
+        patch_artist=True,
+        widths=0.5,
+        whis=[5, 95],
+    )
+    bp['boxes'][0].set_facecolor('coral')
+    bp['boxes'][0].set_alpha(0.6)
+
+    _label_with_units(ax, "y", "Compression Ratio")
+    ax.set_title(title, fontsize=14, fontweight='bold')
+    ax.set_xticks([])
+
+    # Apply modern style
+    _apply_modern_style(ax)
+
+    # Add reference lines
+    ax.axhline(y=2.0, color='green', linestyle='--', alpha=0.5, label='Good (>2x)')
+    ax.axhline(y=1.5, color='orange', linestyle='--', alpha=0.5, label='OK (>1.5x)')
+    ax.legend(fontsize=9, loc='upper right')
+
+    # Add stats text
+    stats_text = f"Median: {np.median(compression_ratios):.2f}x\n"
+    stats_text += f"Mean: {np.mean(compression_ratios):.2f}x"
+
+    ax.text(0.02, 0.97, stats_text,
+            transform=ax.transAxes,
+            verticalalignment='top',
+            horizontalalignment='left',
+            bbox=dict(boxstyle='round', facecolor='wheat', alpha=0.5),
+            fontsize=10)
+
+    plt.tight_layout()
+
+    if save_path:
+        plt.savefig(save_path, dpi=300, bbox_inches='tight')
+        print(f"Saved to {save_path}")
+
+    return fig, ax
+
+
+def plot_branch_distributions_by_dataset(
+    results: List[Dict],
+    dataset_map: Dict[str, str],
+    title: str = "Branch Distributions by Dataset",
+    figsize: tuple = (12, 6),
+    save_path: Optional[str] = None,
+):
+    """Plot side-by-side box plots of branch characteristics per dataset.
+
+    Parameters
+    ----------
+    results : List[dict]
+        File inspection results
+    dataset_map : Dict[str, str]
+        Mapping from filepath to dataset name
+    title : str
+        Plot title
+    figsize : tuple
+        Figure size
+    save_path : str, optional
+        Path to save figure
+
+    Examples
+    --------
+    >>> plot_branch_distributions_by_dataset(results, dataset_map)
+    """
+    # Group results by dataset
+    grouped = group_by_dataset(results, dataset_map)
+
+    # Compute stats for each dataset
+    dataset_sizes = {}
+    dataset_compressions = {}
+
+    for dataset_name, dataset_results in grouped.items():
+        stats = compute_branch_statistics(dataset_results)
+        dataset_sizes[dataset_name] = [s / 1024 / 1024 for s in stats["branch_sizes"]]  # MB
+        dataset_compressions[dataset_name] = stats["compression_ratios"]
+
+    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=figsize)
+
+    # Branch sizes per dataset
+    dataset_names = list(dataset_sizes.keys())
+    size_data = [dataset_sizes[name] for name in dataset_names]
+
+    bp1 = ax1.boxplot(size_data, tick_labels=dataset_names, patch_artist=True, whis=[5, 95])
+    for patch in bp1['boxes']:
+        patch.set_facecolor('steelblue')
+        patch.set_alpha(0.6)
+
+    _label_with_units(ax1, "y", "Branch Size", "MB")
+    ax1.set_title("Branch Sizes", fontsize=13, fontweight='bold')
+    ax1.tick_params(axis='x', rotation=45)
+
+    # Apply modern style
+    _apply_modern_style(ax1)
+
+    # Compression ratios per dataset
+    compression_data = [dataset_compressions[name] for name in dataset_names if dataset_compressions[name]]
+    compression_labels = [name for name in dataset_names if dataset_compressions[name]]
+
+    if compression_data:
+        bp2 = ax2.boxplot(compression_data, tick_labels=compression_labels, patch_artist=True, whis=[5, 95])
+        for patch in bp2['boxes']:
+            patch.set_facecolor('coral')
+            patch.set_alpha(0.6)
+
+        ax2.axhline(y=2.0, color='green', linestyle='--', alpha=0.5, linewidth=1)
+        ax2.axhline(y=1.5, color='orange', linestyle='--', alpha=0.5, linewidth=1)
+
+    _label_with_units(ax2, "y", "Compression Ratio")
+    ax2.set_title("Compression Ratios", fontsize=13, fontweight='bold')
+    ax2.tick_params(axis='x', rotation=45)
+
+    # Apply modern style
+    _apply_modern_style(ax2)
+
+    fig.suptitle(title, fontsize=14, fontweight='bold', y=1.02)
+    plt.tight_layout()
+
+    if save_path:
+        plt.savefig(save_path, dpi=300, bbox_inches='tight')
+        print(f"Saved to {save_path}")
+
+    return fig, (ax1, ax2)
+
+
+def plot_file_size_distribution(
+    results: List[Dict],
+    size_summary: Optional[Dict] = None,
+    title: str = "File Size Distribution",
+    figsize: tuple = (10, 6),
+    save_path: Optional[str] = None,
+):
+    """Plot histogram of file sizes.
+
+    Parameters
+    ----------
+    results : List[dict]
+        File inspection results
+    size_summary : Dict, optional
+        Optional size summary produced by :func:`inspector.rucio.fetch_file_sizes`.
+        When provided, histogram data is derived from this summary. Otherwise the
+        ``file_size_bytes`` attribute from *results* is used (suitable for local files).
+    title : str
+        Plot title
+    figsize : tuple
+        Figure size
+    save_path : str, optional
+        Path to save figure
+
+    Examples
+    --------
+    >>> plot_file_size_distribution(results)
+    >>> size_summary = fetch_file_sizes(dataset_manager, processes=["signal"])
+    >>> plot_file_size_distribution(results, size_summary=size_summary)
+    """
+    if size_summary:
+        file_sizes_gb = [
+            entry["bytes"] / 1024**3
+            for entry in size_summary.get("files", [])
+            if entry.get("bytes", 0) > 0
+        ]
+    else:
+        file_sizes_gb = [
+            r["file_size_bytes"] / 1024**3
+            for r in results
+            if r["file_size_bytes"] > 0
+        ]
+
+    if not file_sizes_gb:
+        print("No file size data available (all files are remote)")
+        return None, None
+
+    fig, ax = plt.subplots(figsize=figsize)
+
+    ax.hist(file_sizes_gb, bins=30, edgecolor='none', alpha=0.6, color='purple')
+    _label_with_units(ax, "x", "File Size", "GB")
+    _label_with_units(ax, "y", "Number of Files")
+    ax.set_title(title, fontsize=14, fontweight='bold')
+
+    # Apply modern style
+    _apply_modern_style(ax)
+    _apply_scientific_notation(ax, axis="x")
+
+    # Add stats text
+    stats_text = f"Files: {len(file_sizes_gb)}\n"
+    stats_text += f"Mean: {np.mean(file_sizes_gb):.2f} GB\n"
+    stats_text += f"Median: {np.median(file_sizes_gb):.2f} GB\n"
+    stats_text += f"Total: {sum(file_sizes_gb):.1f} GB"
+
+    ax.text(0.98, 0.97, stats_text,
+            transform=ax.transAxes,
+            verticalalignment='top',
+            horizontalalignment='right',
+            bbox=dict(boxstyle='round', facecolor='wheat', alpha=0.5),
+            fontsize=10)
+
+    plt.tight_layout()
+
+    if save_path:
+        plt.savefig(save_path, dpi=300, bbox_inches='tight')
+        print(f"Saved to {save_path}")
+
+    return fig, ax
+
+
+def plot_summary_dashboard(
+    results: List[Dict],
+    dataset_stats: Dict[str, Dict],
+    dataset_map: Dict[str, str],
+    save_path: Optional[str] = None,
+):
+    """Create a comprehensive summary dashboard with all key plots.
+
+    Parameters
+    ----------
+    results : List[dict]
+        All file inspection results
+    dataset_stats : Dict[str, dict]
+        Per-dataset statistics
+    dataset_map : Dict[str, str]
+        Mapping from filepath to dataset name
+    save_path : str, optional
+        Path to save figure
+
+    Examples
+    --------
+    >>> # After running full inspection
+    >>> plot_summary_dashboard(results, dataset_stats, dataset_map,
+    ...                        save_path="input_summary.png")
+    """
+    fig = plt.figure(figsize=(16, 12))
+    gs = fig.add_gridspec(3, 2, hspace=0.35, wspace=0.3)
+
+    # 1. Event distribution
+    ax1 = fig.add_subplot(gs[0, 0])
+    event_counts = [r["num_events"] for r in results]
+    ax1.hist(event_counts, bins=30, edgecolor='none', alpha=0.6, color='steelblue')
+    ax1.set_xlabel("Events per File", fontsize=10)
+    ax1.set_ylabel("Number of Files", fontsize=10)
+    ax1.set_title("Event Distribution", fontweight='bold', fontsize=11)
+    _apply_modern_style(ax1)
+
+    # 2. Dataset comparison - events
+    ax2 = fig.add_subplot(gs[0, 1])
+    datasets = list(dataset_stats.keys())
+    total_events = [stats["total_events"] for stats in dataset_stats.values()]
+    ax2.barh(datasets, total_events, color='coral', edgecolor='none', alpha=0.6)
+    ax2.set_xlabel("Total Events", fontsize=10)
+    ax2.set_title("Events per Dataset", fontweight='bold', fontsize=11)
+    _apply_modern_style(ax2)
+
+    # 3. Dataset comparison - files
+    ax3 = fig.add_subplot(gs[1, 0])
+    num_files = [stats["num_files"] for stats in dataset_stats.values()]
+    ax3.barh(datasets, num_files, color='steelblue', edgecolor='none', alpha=0.6)
+    ax3.set_xlabel("Number of Files", fontsize=10)
+    ax3.set_title("Files per Dataset", fontweight='bold', fontsize=11)
+    _apply_modern_style(ax3)
+
+    # 4. Branch size distribution (aggregated)
+    ax4 = fig.add_subplot(gs[1, 1])
+    stats = compute_branch_statistics(results)
+    sizes_mb = [s / 1024 / 1024 for s in stats["branch_sizes"]]
+    bp = ax4.boxplot(sizes_mb, orientation='vertical', patch_artist=True, widths=0.5, whis=[5, 95])
+    bp['boxes'][0].set_facecolor('mediumseagreen')
+    bp['boxes'][0].set_alpha(0.6)
+    ax4.set_ylabel("Branch Size (MB)", fontsize=10)
+    ax4.set_title("Branch Size Distribution", fontweight='bold', fontsize=11)
+    ax4.set_xticks([])
+    _apply_modern_style(ax4)
+
+    # 5. Branch compression distribution (aggregated)
+    ax5 = fig.add_subplot(gs[2, 0])
+    compression_ratios = stats["compression_ratios"]
+    if compression_ratios:
+        bp2 = ax5.boxplot(compression_ratios, orientation='vertical', patch_artist=True, widths=0.5, whis=[5, 95])
+        bp2['boxes'][0].set_facecolor('coral')
+        bp2['boxes'][0].set_alpha(0.6)
+        ax5.axhline(y=2.0, color='green', linestyle='--', alpha=0.5, linewidth=1)
+        ax5.axhline(y=1.5, color='orange', linestyle='--', alpha=0.5, linewidth=1)
+    ax5.set_ylabel("Compression Ratio", fontsize=10)
+    ax5.set_title("Compression Distribution", fontweight='bold', fontsize=11)
+    ax5.set_xticks([])
+    _apply_modern_style(ax5)
+
+    # 6. Per-dataset branch size comparison
+    ax6 = fig.add_subplot(gs[2, 1])
+    grouped = group_by_dataset(results, dataset_map)
+    dataset_sizes = {}
+    for dataset_name, dataset_results in grouped.items():
+        ds_stats = compute_branch_statistics(dataset_results)
+        dataset_sizes[dataset_name] = [s / 1024 / 1024 for s in ds_stats["branch_sizes"]]
+
+    dataset_names = list(dataset_sizes.keys())
+    size_data = [dataset_sizes[name] for name in dataset_names]
+    if size_data:
+        bp3 = ax6.boxplot(size_data, tick_labels=dataset_names, patch_artist=True, whis=[5, 95])
+        for patch in bp3['boxes']:
+            patch.set_facecolor('steelblue')
+            patch.set_alpha(0.6)
+        ax6.tick_params(axis='x', rotation=45)
+    ax6.set_ylabel("Branch Size (MB)", fontsize=10)
+    ax6.set_title("Branch Sizes by Dataset", fontweight='bold', fontsize=11)
+    _apply_modern_style(ax6)
+
+    fig.suptitle("Input Data Characterization Summary", fontsize=16, fontweight='bold')
+
+    if save_path:
+        plt.savefig(save_path, dpi=300, bbox_inches='tight')
+        print(f"Saved to {save_path}")
+
+    return fig

--- a/cms/src/intccms/metrics/inspector/rucio.py
+++ b/cms/src/intccms/metrics/inspector/rucio.py
@@ -1,0 +1,275 @@
+"""Rucio-backed helpers for inspector size metrics.
+
+This module lets users pull authoritative file-size information from Rucio and
+optionally feed those numbers into the inspector statistics/plotting pipeline.
+The goal is to keep the heavy Rucio lookups opt-in while providing a convenient
+API that mirrors the rest of the inspector tooling.
+
+Typical usage
+-------------
+>>> from intccms.datasets import DatasetManager
+>>> from intccms.metrics.inspector import rucio as inspector_rucio
+>>> dm = DatasetManager(config.datasets)
+>>> size_summary = inspector_rucio.fetch_file_sizes(dm, processes=["signal"])
+>>> console.print(inspector_rucio.format_dataset_size_table(size_summary))
+>>> stats = aggregate_statistics(results, size_summary=size_summary)
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence
+
+from intccms.datasets import DatasetManager
+from intccms.utils.filters import should_process
+
+try:  # coffea is an optional dependency in some environments
+    from coffea.dataset_tools import rucio_utils  # type: ignore
+except ImportError:  # pragma: no cover - handled gracefully at runtime
+    rucio_utils = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+def _read_listing_files(directory: Path, identifiers: Optional[Sequence[int]]) -> List[str]:
+    """Return LFNs from listing files inside *directory*."""
+    if identifiers is None:
+        listing_files = sorted(directory.glob("*.txt"))
+    else:
+        listing_files = [directory / f"{idx}.txt" for idx in identifiers]
+
+    lfns: List[str] = []
+    for listing in listing_files:
+        if not listing.is_file():
+            logger.debug("Skipping missing listing file: %s", listing)
+            continue
+        for line in listing.read_text().splitlines():
+            path = line.strip()
+            if path:
+                lfns.append(path)
+    return lfns
+
+
+def _build_filepath(lfn: str, redirector: Optional[str]) -> str:
+    """Combine redirector prefix (if any) with logical file name."""
+    if redirector:
+        return f"{redirector}{lfn}"
+    return lfn
+
+
+def _strip_redirector(filepath: str) -> str:
+    """Remove XRootD redirector from a path to recover the logical file name."""
+    if filepath.startswith("root://"):
+        stripped = filepath[len("root://") :]
+        if "/" not in stripped:
+            return filepath
+        _, rest = stripped.split("/", 1)
+        return "/" + rest.lstrip("/")
+    return filepath
+
+
+def _format_bytes(num_bytes: float) -> str:
+    """Human-readable byte formatting."""
+    if num_bytes <= 0:
+        return "0 B"
+    units = ["B", "KB", "MB", "GB", "TB", "PB"]
+    value = float(num_bytes)
+    magnitude = 0
+    while value >= 1024 and magnitude < len(units) - 1:
+        value /= 1024.0
+        magnitude += 1
+    return f"{value:.2f} {units[magnitude]}"
+
+
+def fetch_file_sizes(
+    dataset_manager: DatasetManager,
+    *,
+    processes: Optional[Iterable[str]] = None,
+    identifiers: Optional[Iterable[int]] = None,
+    max_files_per_process: Optional[int] = None,
+    scope: str = "cms",
+    rucio_client=None,
+) -> Dict:
+    """Collect per-file byte information for datasets managed by DatasetManager.
+
+    Parameters
+    ----------
+    dataset_manager
+        Dataset manager created from the analysis configuration.
+    processes
+        Optional iterable of process names to restrict the lookup; if None,
+        all configured processes are queried.
+    identifiers
+        Optional iterable of listing file indices (e.g. [0, 1]) to restrict
+        the lookup to specific `N.txt` files inside each dataset directory.
+    max_files_per_process
+        Optional cap on the number of files per process to query (useful for quick
+        spot checks).
+    scope
+        Rucio scope to use for file queries (defaults to ``cms``).
+    rucio_client
+        Pre-initialized Rucio client. If omitted, ``coffea.dataset_tools.rucio_utils``
+        is used to create one lazily.
+
+    Returns
+    -------
+    dict
+        Summary structure with the following keys:
+        - ``files``: list of ``{"dataset", "lfn", "filepath", "bytes"}`` entries
+        - ``datasets``: mapping of dataset -> aggregated info (total bytes, files,…)
+        - ``total_bytes`` / ``total_files``: overall aggregates
+        - ``scope``: Rucio scope used for lookups
+        - ``errors``: list of ``{"lfn", "error"}`` entries for failed lookups
+
+    Notes
+    -----
+    The helper queries Rucio replicas for each logical file name. For large campaigns
+    you may want to cache the returned summary to avoid repeated lookups.
+    """
+    if rucio_client is None:
+        if rucio_utils is None:
+            raise RuntimeError(
+                "coffea.dataset_tools.rucio_utils is required to create a Rucio client"
+            )
+        rucio_client = rucio_utils.get_rucio_client()
+
+    process_filter = set(processes) if processes is not None else None
+    summary = {
+        "files": [],
+        "datasets": {},
+        "total_bytes": 0,
+        "total_files": 0,
+        "scope": scope,
+        "errors": [],
+    }
+
+    for process in dataset_manager.list_processes():
+        if not should_process(process, process_filter):
+            continue
+
+        try:
+            directories = dataset_manager.get_dataset_directories(process)
+            redirector = dataset_manager.get_redirector(process)
+        except KeyError as exc:
+            logger.warning("Skipping process '%s': %s", process, exc)
+            continue
+
+        lfns: List[str] = []
+        for directory in directories:
+            lfns.extend(_read_listing_files(Path(directory), identifiers))
+
+        if not lfns:
+            continue
+
+        if max_files_per_process is not None:
+            lfns = lfns[:max_files_per_process]
+
+        # Group LFNs by dataset name derived from the LFN structure
+        dataset_groups: Dict[str, Dict[str, any]] = {}
+        for lfn in lfns:
+            parts = lfn.strip("/").split("/")
+            if len(parts) < 6:
+                summary["errors"].append({"dataset": process, "lfn": lfn, "error": "unable_to_parse_dataset"})
+                continue
+            prefix = "/" + "/".join(parts[:3])  # /store/mc/Run...
+            dataset_name = "/" + "/".join(parts[3:6])  # /ZPrime.../NANOAODSIM/...
+            dataset_groups.setdefault(dataset_name, {"prefix": prefix, "lfns": set()})["lfns"].add(lfn)
+
+        size_map: Dict[str, int] = {}
+        for dataset_name, info in dataset_groups.items():
+            try:
+                files_iter = rucio_client.list_files(scope=scope, name=dataset_name)
+            except Exception as error:
+                logger.warning("Failed to list files for dataset %s: %s", dataset_name, error)
+                for lfn in info["lfns"]:
+                    summary["errors"].append({"dataset": process, "lfn": lfn, "error": str(error)})
+                continue
+
+            for entry in files_iter:
+                name = entry.get("name")
+                if not name:
+                    continue
+                full_lfn = f"{info['prefix']}/{dataset_name.strip('/')}/{name}"
+                if full_lfn in info["lfns"]:
+                    try:
+                        size_map[full_lfn] = int(entry.get("bytes", 0))
+                    except Exception:
+                        size_map[full_lfn] = 0
+
+        dataset_files = []
+        for lfn in lfns:
+            filepath = _build_filepath(lfn, redirector)
+            size_bytes = size_map.get(lfn, 0)
+            if not size_bytes:
+                summary["errors"].append({"dataset": process, "lfn": lfn, "error": "size_not_found"})
+
+            entry = {
+                "dataset": process,
+                "lfn": lfn,
+                "filepath": filepath,
+                "bytes": size_bytes,
+            }
+            dataset_files.append(entry)
+            summary["files"].append(entry)
+
+        total_bytes_dataset = sum(item["bytes"] for item in dataset_files)
+        dataset_info = {
+            "dataset": process,
+            "files": dataset_files,
+            "num_files": len(dataset_files),
+            "total_bytes": total_bytes_dataset,
+            "avg_bytes_per_file": (
+                total_bytes_dataset / len(dataset_files) if dataset_files else 0
+            ),
+        }
+        summary["datasets"][process] = dataset_info
+        summary["total_bytes"] += total_bytes_dataset
+        summary["total_files"] += len(dataset_files)
+
+    return summary
+
+
+def format_dataset_size_table(size_summary: Dict):
+    """Return a Rich table summarising total bytes per dataset."""
+    from rich.table import Table  # Local import to avoid Rich dependency during tests
+
+    table = Table(title="Dataset File Sizes", show_header=True, header_style="bold cyan")
+    table.add_column("Dataset", style="cyan")
+    table.add_column("Files", justify="right")
+    table.add_column("Total Size", justify="right", style="magenta")
+    table.add_column("Avg Size/File", justify="right", style="green")
+
+    for dataset, info in sorted(size_summary.get("datasets", {}).items()):
+        num_files = info.get("num_files", 0)
+        total_bytes = info.get("total_bytes", 0)
+        avg_size = info.get("avg_bytes_per_file", 0)
+        table.add_row(
+            dataset,
+            f"{num_files:,}",
+            _format_bytes(total_bytes),
+            _format_bytes(avg_size),
+        )
+
+    table.add_row(
+        "[bold]TOTAL[/bold]",
+        f"{size_summary.get('total_files', 0):,}",
+        _format_bytes(size_summary.get("total_bytes", 0)),
+        "",
+    )
+    return table
+
+
+def build_size_lookup(size_summary: Dict) -> Dict[str, int]:
+    """Construct mapping from file path / LFN to byte counts."""
+    lookup: Dict[str, int] = {}
+    for entry in size_summary.get("files", []):
+        filepath = entry.get("filepath")
+        if filepath:
+            lookup[filepath] = entry.get("bytes", 0)
+        lfn = entry.get("lfn")
+        if lfn:
+            lookup[lfn] = entry.get("bytes", 0)
+        if filepath:
+            lookup[_strip_redirector(filepath)] = entry.get("bytes", 0)
+    return lookup


### PR DESCRIPTION
## Summary

Adds `intccms.metrics.inspector` for characterizing input ROOT files with distributed Dask.

- `core`: per-file inspection, distributed driver, error summary
- `aggregator`: overall stats, dataset grouping, compression stats, top-branch ranking
- `format`: rich-printable tables (overall, branch, dataset, compression)
- `plot`: visualizations
- `integration`: helpers to feed files in from `DatasetManager`
- `rucio`: Rucio-backed file-size lookup