### PR TITLE
fix: chunksize propagation was allowed in processor workflow instead of preprocessing

### DIFF
--- a/cms/README.md
+++ b/cms/README.md
@@ -323,6 +323,20 @@ Set `config["general"]["run_metadata_generation"] = True` to run it (requires a 
 
 **Re-run when**: datasets change, files are added/removed, or you switch redirectors.
 
+### Changing chunksize
+
+`DatasetMetadataManager(chunksize=N)` sets how many events go into each `WorkItem` produced by coffea preprocess (default 200_000):
+
+```python
+metadata_generator = DatasetMetadataManager(
+    dataset_manager, output_manager,
+    config=validated_config,
+    chunksize=500_000,
+)
+```
+
+For the analysis pass on a `fileset` (skimming-input path), `run_processor_workflow(..., chunksize=N)` controls coffea's preprocess the same way. When premade workitems are passed instead, the kwarg is ignored. Chunksize was fixed at metadata generation time.
+
 ### [Advanced] What are the components of the preprocessing workflow?
 
 The metadata extraction pipeline lives in `src/intccms/metadata_extractor/` and has four components:

--- a/cms/example_cms/configs/skim.py
+++ b/cms/example_cms/configs/skim.py
@@ -314,7 +314,6 @@ def default_skim_selection(puppimet, hlt):
 skimming_config = {
     "function": default_skim_selection,
     "use": [ObjVar("PuppiMET", None), ObjVar("HLT", None)],
-    "chunk_size": 200_000,
     "tree_name": "Events",
     # "output": {
     #     "format": "parquet",

--- a/cms/src/intccms/analysis/runner.py
+++ b/cms/src/intccms/analysis/runner.py
@@ -80,7 +80,9 @@ def run_processor_workflow(
     schema : Any, optional
         NanoAOD schema for coffea, by default NanoAODSchema
     chunksize : int
-        Number of events per chunk, by default 200_000
+        Events per chunk for Runner.preprocess. Only applies to the fileset /
+        skimming-input path; ignored when workitems are provided (workitems
+        carry their own entry ranges). Default 200_000.
     preload : bool, optional
         If True, pass coffea's ``trace`` function to the Runner so it
         preloads only the branches the processor accesses. Default False.
@@ -197,12 +199,15 @@ def run_processor_workflow(
         if config.general.use_skimmed_input:
             skim_format = config.preprocess.skimming.output.format
             runner_kwargs["format"] = "parquet" if skim_format == "parquet" else "root"
-            
+
+        # chunksize only matters when Runner.preprocess builds chunks itself.
+        if use_fileset:
+            runner_kwargs["chunksize"] = chunksize
+
         # Create coffea Runner
         runner = Runner(
             executor=executor,
             schema=schema,
-            chunksize=chunksize,
             savemetrics=True,
             skipbadfiles=skipbadfiles,
             **runner_kwargs,
@@ -232,7 +237,7 @@ def run_processor_workflow(
                 **run_kwargs,
             )
         else:
-            logger.info(f"Processing {len(workitems)} work items with chunksize={chunksize}")
+            logger.info(f"Processing {len(workitems)} work items")
             output, report = runner(
                 workitems,
                 processor_instance=processor,

--- a/cms/src/intccms/analysis/runner.py
+++ b/cms/src/intccms/analysis/runner.py
@@ -44,7 +44,7 @@ def run_processor_workflow(
     workitems: Optional[List[WorkItem]] = None,
     executor: Any = None,
     schema: Any = NanoAODSchema,
-    chunksize: Optional[int] = None,
+    chunksize: int = 200_000,
     preload: bool = False,
     post: Optional[Callable] = None,
     skipbadfiles: Union[bool, Tuple[Type[BaseException], ...]] = DEFAULT_PROCESS_SKIPBADFILES,
@@ -79,8 +79,8 @@ def run_processor_workflow(
         User controls which executor to use
     schema : Any, optional
         NanoAOD schema for coffea, by default NanoAODSchema
-    chunksize : int, optional
-        Number of events per chunk, by default None (uses config value or 100k)
+    chunksize : int
+        Number of events per chunk, by default 200_000
     preload : bool, optional
         If True, pass coffea's ``trace`` function to the Runner so it
         preloads only the branches the processor accesses. Default False.
@@ -192,13 +192,6 @@ def run_processor_workflow(
                 output_manager=output_manager,
                 metadata_lookup=metadata_lookup,
             )
-
-        # Determine chunksize
-        if chunksize is None:
-            if hasattr(config, 'preprocess') and hasattr(config.preprocess, 'skimming'):
-                chunksize = config.preprocess.skimming.chunk_size
-            else:
-                chunksize = 100_000
 
         runner_kwargs = {}
         if config.general.use_skimmed_input:

--- a/cms/src/intccms/metadata_extractor/extractor.py
+++ b/cms/src/intccms/metadata_extractor/extractor.py
@@ -34,7 +34,7 @@ class CoffeaMetadataExtractor:
         self,
         executor: Any = None,
         schema: Any = None,
-        chunksize: int = 100_000,
+        chunksize: int = 200_000,
         skipbadfiles: Union[bool, Tuple[Type[BaseException], ...]] = DEFAULT_PREPROCESS_SKIPBADFILES,
     ):
         """
@@ -49,7 +49,7 @@ class CoffeaMetadataExtractor:
             Schema for parsing ROOT files (e.g., NanoAODSchema).
             If None, uses NanoAODSchema by default.
         chunksize : int, optional
-            Number of events per chunk for WorkItem splitting, default 100_000
+            Number of events per chunk for WorkItem splitting, default 200_000
         skipbadfiles : bool or tuple of exception types, optional
             Forwarded to coffea's Runner. Defaults to DEFAULT_PREPROCESS_SKIPBADFILES.
             Pass False to hard-fail on any bad file, True for coffea's built-in
@@ -108,7 +108,10 @@ class CoffeaMetadataExtractor:
         Exception
             If coffea preprocessing fails
         """
-        logger.info("Extracting metadata using coffea Runner.preprocess")
+        logger.info(
+            "Extracting metadata using coffea Runner.preprocess "
+            f"(chunksize={self.runner.chunksize})"
+        )
         try:
             # Run the coffea preprocess function on the provided fileset
             workitems = self.runner.preprocess(

--- a/cms/src/intccms/metadata_extractor/manager.py
+++ b/cms/src/intccms/metadata_extractor/manager.py
@@ -95,7 +95,7 @@ class DatasetMetadataManager:
         dataset_manager: DatasetManager,
         output_manager: Any,
         config: Optional[Any] = None,
-        chunksize=100_000,
+        chunksize=200_000,
     ):
         """
         Initialize DatasetMetadataManager.

--- a/cms/src/intccms/metadata_extractor/manager.py
+++ b/cms/src/intccms/metadata_extractor/manager.py
@@ -95,6 +95,7 @@ class DatasetMetadataManager:
         dataset_manager: DatasetManager,
         output_manager: Any,
         config: Optional[Any] = None,
+        chunksize=100_000,
     ):
         """
         Initialize DatasetMetadataManager.
@@ -113,20 +114,15 @@ class DatasetMetadataManager:
         self.output_manager = output_manager
         self.output_directory = self.output_manager.metadata_dir
         self.config = config
+        self.chunksize=chunksize
 
         # Extract config-derived attributes
         if config:
             self.generate_metadata = config.general.run_metadata_generation
             self.processes_filter = getattr(config.general, 'processes', None)
-            # Extract chunksize from config
-            if hasattr(config, 'preprocess') and hasattr(config.preprocess, 'skimming'):
-                self.chunksize = config.preprocess.skimming.chunk_size
-            else:
-                self.chunksize = 100_000
         else:
             self.generate_metadata = True
             self.processes_filter = None
-            self.chunksize = 100_000
 
         # Initialize fileset builder (doesn't need executor)
         self.fileset_builder = FilesetBuilder(dataset_manager, output_manager)

--- a/cms/src/intccms/schema/skimming.py
+++ b/cms/src/intccms/schema/skimming.py
@@ -52,12 +52,6 @@ class SkimOutputConfig(SubscriptableModel):
 
 class SkimmingConfig(FunctorConfig):
     """Configuration for workitem-based skimming selections and output"""
-
-    # File handling configuration
-    chunk_size: Annotated[
-        int,
-        Field(default=100_000, description="Number of events to process per chunk (used for configuration compatibility)")
-    ]
     tree_name: Annotated[
         str,
         Field(default="Events", description="ROOT tree name for input and output files")


### PR DESCRIPTION
## Summary

`chunksize` is only used by coffea's `Runner.preprocess`. Before this PR it was also part of the `preprocess.skimming` config and accepted by `run_processor_workflow` even when premade workitems are passed. In that case the value was ignored, because each workitem already carries its own entry range. This PR removes it from the places where it had no effect and keeps it only where it does.

Changes:
- Removed `chunk_size` from the `preprocess.skimming` schema and the example config. `DatasetMetadataManager` now takes a plain `chunksize` kwarg instead of reading it from `config.preprocess.skimming.chunk_size`.
- `run_processor_workflow` keeps its `chunksize` kwarg but only passes it to coffea's `Runner` in the fileset / skimming-input branch. In the workitems branch the `Runner` is built without it, and the misleading "chunksize=..." log line is gone.
- Default chunksize bumped from 100_000 to 200_000 in `DatasetMetadataManager` and `CoffeaMetadataExtractor`.
- The preprocess info log now reports the chunksize being used.
- README has a new "Changing chunksize" subsection covering both knobs and the workitems caveat.