### PR TITLE
feat: add dataset_timeline helper for per-dataset chunk activity over time

### DIFF
--- a/cms/full_run_200gbps.ipynb
+++ b/cms/full_run_200gbps.ipynb
@@ -633,7 +633,19 @@
     "\n",
     "# Data throughput over time\n",
     "fig, ax = plot_throughput_timeline(metrics[\"chunk_info\"], tracking_data)\n",
-    "plt.show()"
+    "plt.show()\n",
+    "from intccms.metrics.dataset_timeline import plot_dataset_timeline\n",
+    "\n",
+    "# ========================================================================\n",
+    "# Dataset processing timeline\n",
+    "# This shows how many chunks per dataset were active at each moment.\n",
+    "# ========================================================================\n",
+    "print(\"\\n📊 Dataset Processing Timeline\")\n",
+    "try:\n",
+    "  plot_dataset_timeline(collector.chunk_metrics, bin_seconds=1.0, output_manager=output_manager)\n",
+    "  plt.show()\n",
+    "except Exception as e:\n",
+    "  print(f\"⚠️  Dataset timeline plot unavailable: {e}\")\n"
    ]
   },
   {

--- a/cms/full_run_200gbps_replicate_legacy.ipynb
+++ b/cms/full_run_200gbps_replicate_legacy.ipynb
@@ -635,7 +635,19 @@
     "\n",
     "# Data throughput over time\n",
     "fig, ax = plot_throughput_timeline(metrics[\"chunk_info\"], tracking_data)\n",
-    "plt.show()"
+    "plt.show()\n",
+    "from intccms.metrics.dataset_timeline import plot_dataset_timeline\n",
+    "\n",
+    "# ========================================================================\n",
+    "# Dataset processing timeline\n",
+    "# This shows how many chunks per dataset were active at each moment.\n",
+    "# ========================================================================\n",
+    "print(\"\\n📊 Dataset Processing Timeline\")\n",
+    "try:\n",
+    "  plot_dataset_timeline(collector.chunk_metrics, bin_seconds=1.0, output_manager=output_manager)\n",
+    "  plt.show()\n",
+    "except Exception as e:\n",
+    "  print(f\"⚠️  Dataset timeline plot unavailable: {e}\")\n"
    ]
   },
   {

--- a/cms/full_run_haas_or_not.ipynb
+++ b/cms/full_run_haas_or_not.ipynb
@@ -424,6 +424,31 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from intccms.metrics.dataset_timeline import plot_dataset_timeline\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# Per-run dataset processing timeline\n",
+    "for key in (\"haas\", \"local\"):\n",
+    "    r = results[key]\n",
+    "    chunks = r[\"metrics\"].get(\"raw_chunk_metrics\")\n",
+    "    if not chunks:\n",
+    "        continue\n",
+    "    print(f\"\\n📊 Dataset Processing Timeline — {r['label']}\")\n",
+    "    try:\n",
+    "      plot_dataset_timeline(chunks, bin_seconds=1.0,\n",
+    "                            output_manager=output_manager,\n",
+    "                            filename=f\"dataset_timeline_{key}.png\")\n",
+    "      plt.show()\n",
+    "    except Exception as e:\n",
+    "      print(f\"⚠️  Dataset timeline plot unavailable: {e}\")\n"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/cms/full_run_histserv.ipynb
+++ b/cms/full_run_histserv.ipynb
@@ -481,6 +481,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from intccms.metrics.dataset_timeline import plot_dataset_timeline\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# ========================================================================\n",
+    "# Dataset processing timeline\n",
+    "# This shows how many chunks per dataset were active at each moment.\n",
+    "# ========================================================================\n",
+    "print(\"\\n📊 Dataset Processing Timeline\")\n",
+    "try:\n",
+    "  plot_dataset_timeline(collector.chunk_metrics, bin_seconds=1.0, output_manager=output_manager)\n",
+    "  plt.show()\n",
+    "except Exception as e:\n",
+    "  print(f\"⚠️  Dataset timeline plot unavailable: {e}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "report, output"
    ]
   },

--- a/cms/full_run_servicex_preskim.ipynb
+++ b/cms/full_run_servicex_preskim.ipynb
@@ -554,7 +554,19 @@
     "  plot_data_access_percentage,\n",
     "  plot_runtime_distribution,\n",
     "  plot_runtime_vs_events,\n",
-    ")"
+    ")\n",
+    "from intccms.metrics.dataset_timeline import plot_dataset_timeline\n",
+    "\n",
+    "# ========================================================================\n",
+    "# Dataset processing timeline\n",
+    "# This shows how many chunks per dataset were active at each moment.\n",
+    "# ========================================================================\n",
+    "print(\"\\n📊 Dataset Processing Timeline\")\n",
+    "try:\n",
+    "  plot_dataset_timeline(collector.chunk_metrics, bin_seconds=1.0, output_manager=output_manager)\n",
+    "  plt.show()\n",
+    "except Exception as e:\n",
+    "  print(f\"⚠️  Dataset timeline plot unavailable: {e}\")\n"
    ]
   },
   {

--- a/cms/full_run_with_metrics.ipynb
+++ b/cms/full_run_with_metrics.ipynb
@@ -541,7 +541,8 @@
     "  plot_data_access_percentage,\n",
     "  plot_runtime_distribution,\n",
     "  plot_runtime_vs_events,\n",
-    ")"
+    ")\n",
+    "from intccms.metrics.dataset_timeline import plot_dataset_timeline"
    ]
   },
   {
@@ -615,7 +616,19 @@
     "  fig, ax = plot_cpu_utilization_per_worker_timeline(tracking_data)\n",
     "  plt.show()\n",
     "except Exception as e:\n",
-    "  print(f\"⚠️  CPU plot unavailable: {e}\")\n"
+    "  print(f\"⚠️  CPU plot unavailable: {e}\")\n",
+    "\n",
+    "\n",
+    "# ========================================================================\n",
+    "# Dataset processing timeline\n",
+    "# This shows how many chunks per dataset were active at each moment.\n",
+    "# ========================================================================\n",
+    "print(\"\\n📊 Dataset Processing Timeline\")\n",
+    "try:\n",
+    "  plot_dataset_timeline(collector.chunk_metrics, bin_seconds=1.0, output_manager=output_manager)\n",
+    "  plt.show()\n",
+    "except Exception as e:\n",
+    "  print(f\"⚠️  Dataset timeline plot unavailable: {e}\")\n"
    ]
   },
   {

--- a/cms/full_run_with_metrics_rntuples.ipynb
+++ b/cms/full_run_with_metrics_rntuples.ipynb
@@ -582,7 +582,19 @@
     "  plot_data_access_percentage,\n",
     "  plot_runtime_distribution,\n",
     "  plot_runtime_vs_events,\n",
-    ")"
+    ")\n",
+    "from intccms.metrics.dataset_timeline import plot_dataset_timeline\n",
+    "\n",
+    "# ========================================================================\n",
+    "# Dataset processing timeline\n",
+    "# This shows how many chunks per dataset were active at each moment.\n",
+    "# ========================================================================\n",
+    "print(\"\\n📊 Dataset Processing Timeline\")\n",
+    "try:\n",
+    "  plot_dataset_timeline(collector.chunk_metrics, bin_seconds=1.0, output_manager=output_manager)\n",
+    "  plt.show()\n",
+    "except Exception as e:\n",
+    "  print(f\"⚠️  Dataset timeline plot unavailable: {e}\")\n"
    ]
   },
   {

--- a/cms/full_run_workflow_modes.ipynb
+++ b/cms/full_run_workflow_modes.ipynb
@@ -139,7 +139,19 @@
     "    plot_throughput_timeline,\n",
     "    plot_runtime_distribution,\n",
     ")\n",
-    "from rich.console import Console"
+    "from rich.console import Console\n",
+    "from intccms.metrics.dataset_timeline import plot_dataset_timeline\n",
+    "\n",
+    "# ========================================================================\n",
+    "# Dataset processing timeline\n",
+    "# This shows how many chunks per dataset were active at each moment.\n",
+    "# ========================================================================\n",
+    "print(\"\\n📊 Dataset Processing Timeline\")\n",
+    "try:\n",
+    "  plot_dataset_timeline(collector.chunk_metrics, bin_seconds=1.0, output_manager=output_manager)\n",
+    "  plt.show()\n",
+    "except Exception as e:\n",
+    "  print(f\"⚠️  Dataset timeline plot unavailable: {e}\")\n"
    ]
   },
   {

--- a/cms/src/intccms/metrics/dataset_timeline.py
+++ b/cms/src/intccms/metrics/dataset_timeline.py
@@ -1,0 +1,129 @@
+"""Build a per-dataset processing timeline from roastcoffea chunk metrics.
+
+Given the chunk-level records that ``roastcoffea.MetricsCollector`` collects
+(``collector.chunk_metrics`` after ``extract_metrics_from_output``), this
+module produces a time series of how many chunks per dataset were active in
+each time bin. The output can be overlaid on a throughput time series to see
+which datasets were running during throughput peaks or dips.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterable, Optional, Union
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from intccms.utils.output import OutputDirectoryManager
+
+
+def build_active_chunks_timeline(
+    chunk_metrics: Iterable[dict[str, Any]],
+    bin_seconds: float = 1.0,
+    t0: Optional[float] = None,
+    t1: Optional[float] = None,
+) -> pd.DataFrame:
+    """Count chunks active per dataset in each time bin.
+
+    Parameters
+    ----------
+    chunk_metrics : iterable of dict
+        Records with ``t_start``, ``t_end``, ``dataset`` (UNIX timestamps).
+    bin_seconds : float
+        Time bin width.
+    t0, t1 : float, optional
+        UNIX-timestamp range to cover. Default: span of the data.
+
+    Returns
+    -------
+    pd.DataFrame
+        Indexed by elapsed seconds since ``t0``. One column per dataset, value
+        is the count of chunks whose ``[t_start, t_end)`` overlapped the bin.
+    """
+    records = [
+        c for c in chunk_metrics
+        if c.get("dataset") is not None and "t_start" in c and "t_end" in c
+    ]
+    if not records:
+        raise ValueError("chunk_metrics has no usable records (need t_start, t_end, dataset)")
+
+    starts = np.array([c["t_start"] for c in records], dtype=float)
+    ends = np.array([c["t_end"] for c in records], dtype=float)
+    datasets = np.array([c["dataset"] for c in records])
+
+    if t0 is None:
+        t0 = float(starts.min())
+    if t1 is None:
+        t1 = float(ends.max())
+
+    n_bins = max(1, int(np.ceil((t1 - t0) / bin_seconds)))
+    bin_edges = t0 + np.arange(n_bins + 1) * bin_seconds
+    bin_centers = (bin_edges[:-1] + bin_edges[1:]) / 2
+
+    unique_datasets = sorted(set(datasets.tolist()))
+    counts = {ds: np.zeros(n_bins, dtype=int) for ds in unique_datasets}
+
+    for s, e, ds in zip(starts, ends, datasets):
+        i0 = max(0, int((s - t0) / bin_seconds))
+        i1 = min(n_bins, int(np.ceil((e - t0) / bin_seconds)))
+        if i1 > i0:
+            counts[ds][i0:i1] += 1
+
+    return pd.DataFrame(counts, index=bin_centers - t0)
+
+
+def plot_dataset_timeline(
+    chunk_metrics: Iterable[dict[str, Any]],
+    bin_seconds: float = 1.0,
+    ax: Optional[plt.Axes] = None,
+    output_manager: Optional[OutputDirectoryManager] = None,
+    output_path: Optional[Union[str, Path]] = None,
+    filename: str = "dataset_timeline.png",
+) -> plt.Axes:
+    """Stacked-area plot of active chunks per dataset over time.
+
+    Parameters
+    ----------
+    chunk_metrics : iterable of dict
+        See :func:`build_active_chunks_timeline`.
+    bin_seconds : float
+        Time bin width passed through to the data builder.
+    ax : matplotlib.axes.Axes, optional
+        Plot onto an existing axes (useful for overlaying on a throughput
+        panel via ``plt.subplots(2, 1, sharex=True)``). If None a new figure
+        is created.
+    output_manager : OutputDirectoryManager, optional
+        If set and ``output_path`` is not, the figure is saved to
+        ``output_manager.plots_dir / filename``.
+    output_path : str or Path, optional
+        Explicit destination for the figure. Takes precedence over
+        ``output_manager``.
+    filename : str
+        Filename used when saving via ``output_manager``.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+        The axes object the plot was drawn on.
+    """
+    df = build_active_chunks_timeline(chunk_metrics, bin_seconds=bin_seconds)
+    if ax is None:
+        _, ax = plt.subplots(figsize=(12, 5))
+    ax.stackplot(df.index, df.T.values, labels=df.columns)
+    ax.set_xlabel("Elapsed seconds")
+    ax.set_ylabel("Active chunks")
+    ax.set_title(f"Dataset processing timeline (bin={bin_seconds}s)")
+    ax.legend(loc="upper right", fontsize="small", ncol=2)
+    ax.margins(x=0)
+    ax.figure.tight_layout()
+
+    save_to = None
+    if output_path is not None:
+        save_to = Path(output_path)
+    elif output_manager is not None:
+        save_to = Path(output_manager.plots_dir) / filename
+    if save_to is not None:
+        ax.figure.savefig(save_to, dpi=150, bbox_inches="tight")
+    return ax


### PR DESCRIPTION
## Summary

Adds a helper that turns `roastcoffea.MetricsCollector.chunk_metrics` into a per-dataset active-chunk time series. Overlay it on the throughput plot and you can see which datasets were running during throughput peaks or dips, spot scheduling imbalance between datasets, or long tails on a single dataset.

Changes:
- New module `src/intccms/metrics/dataset_timeline.py` with two functions:
  - `build_active_chunks_timeline(chunk_metrics, bin_seconds=1.0, t0=None, t1=None)` returns a pandas DataFrame indexed by elapsed seconds, one column per dataset, value is the count of chunks whose `[t_start, t_end)` overlapped the bin.
  - `plot_dataset_timeline(chunk_metrics, bin_seconds=1.0, ax=None, output_manager=None, output_path=None, filename=\"dataset_timeline.png\")` draws a stacked-area plot. Pass an `OutputDirectoryManager` to save to `<root>/plots/dataset_timeline.png`, pass an explicit `output_path` to override, or pass an existing `ax` to overlay on a `plt.subplots(2, 1, sharex=True)` panel alongside throughput.
- Wired the plot into every metrics-collecting notebook so it lands next to the throughput plot (or in the metrics-comparison section for the multi-run notebook):
  - `full_run_with_metrics.ipynb`, `full_run_with_metrics_rntuples.ipynb`
  - `full_run_200gbps.ipynb`, `full_run_200gbps_replicate_legacy.ipynb`
  - `full_run_servicex_preskim.ipynb`
  - `full_run_workflow_modes.ipynb`
  - `full_run_histserv.ipynb` (new cell after the MetricsCollector block since the notebook has no roastcoffea-plot section)
  - `full_run_haas_or_not.ipynb` (per-run loop over `results["haas"]` / `results["local"]` saving each to a labelled filename)

Usage:

```python
from intccms.metrics.dataset_timeline import plot_dataset_timeline
plot_dataset_timeline(collector.chunk_metrics, bin_seconds=1.0,
                     output_manager=output_manager)
```

Notebooks not touched because they don't actually instantiate `MetricsCollector`: `full_run_200gbps_preload_vs_not.ipynb`, `full_run_skim_formats.ipynb`.