### PR TITLE
feat: add analysis processor that materialises extra branches

### DIFF
--- a/cms/README.md
+++ b/cms/README.md
@@ -491,7 +491,7 @@ Three layers in `src/intccms/analysis/`:
 |------|-------|------|
 | `base.py` | `Analysis` | Generic base class. Handles corrections (correctionlib + custom functions), object masks, baseline selection, ghost observables. Experiment-agnostic. |
 | `cms.py` | `CMSAnalysis(Analysis)` | CMS-specific implementation. Initializes histograms, runs the histogramming loop (nominal + systematic variations), runs statistical inference via cabinetry. |
-| `processors.py` | `SkimAndAnalyseProcessor`, `TwoHundredGbpsProcessor` | Coffea processors. `SkimAndAnalyseProcessor` owns a `CMSAnalysis` instance and dispatches to it for the analysis step. |
+| `processors.py` | `SkimAndAnalyseProcessor`, `TwoHundredGbpsProcessor`, `HistServProcessor`, `HistLocalProcessor`, `AnalysisWithExtraBranchesProcessor` | Coffea processors. `SkimAndAnalyseProcessor` owns a `CMSAnalysis` instance and dispatches to it for the analysis step. See the per-class breakdown below. |
 
 The flow per chunk: `SkimAndAnalyseProcessor.process()` → skim selection → optionally save to disk → `CMSAnalysis.process()` → `Analysis.prepare_objects()` (corrections + masks) → `CMSAnalysis.histogramming()` (fill histograms).
 

--- a/cms/README.md
+++ b/cms/README.md
@@ -132,6 +132,7 @@ On an analysis facility (AF), use the notebooks directly &mdash; they install de
 | `full_run_200gbps.ipynb` | I/O throughput benchmark with profiling |
 | `full_run_200gbps_preload_vs_not.ipynb` | Compares the 200gbps workflow with and without `preload=True` |
 | `full_run_200gbps_replicate_legacy.ipynb` | 200gbps run with the branch list hardcoded to the idap-200gbps legacy benchmark (via `prepare_branches_from_list`) for direct comparison |
+| `full_run_analysis_with_extra_branches.ipynb` | Standard analysis flow run through `AnalysisWithExtraBranchesProcessor`, with `extra_branches` defaulted to the idap-200gbps legacy list so throughput numbers can be compared with `full_run_200gbps_replicate_legacy.ipynb` |
 | `xrdcp_throughput.ipynb` | Distributed `xrdcp` via `warm_xcache` under `MetricsCollector` and dask profiling, prints wall-clock and per-worker throughput |
 | `full_run_histserv.ipynb` | Standard workflow with histograms filled via HaaS (histserv) instead of reduce-aggregate |
 | `full_run_haas_or_not.ipynb` | Runs `HistServProcessor` and `HistLocalProcessor` back-to-back and compares metrics plus bin-by-bin histogram outputs |
@@ -496,14 +497,15 @@ The flow per chunk: `SkimAndAnalyseProcessor.process()` → skim selection → o
 
 ### Where does the processor live?
 
-`src/intccms/analysis/processors.py` has four processors:
+`src/intccms/analysis/processors.py` has five processors:
 
 - **`SkimAndAnalyseProcessor`**: The main processor. Per chunk, it: (1) applies skim selection, (2) saves filtered events to disk if enabled, (3) calls `CMSAnalysis.process()` for corrections and histogramming if enabled. All controlled by the config flags above.
 - **`TwoHundredGbpsProcessor`**: Minimal I/O benchmark. Reads and materializes configured branches, returns event count only.
 - **`HistServProcessor`**: HaaS variant. Applies the skim selection and fills histograms via a remote histserv server instead of coffea's reduce step. See [Histogramming as a Service (HaaS)](#histogramming-as-a-service-haas).
 - **`HistLocalProcessor`**: Local-reduce sibling of `HistServProcessor`, kept for HaaS-vs-local comparisons. See same section.
+- **`AnalysisWithExtraBranchesProcessor`**: Runs the same skim filter + `CMSAnalysis` flow as `HistLocalProcessor`, and additionally materializes a constructor-supplied list of `extra_branches` (and optional `extra_mc_branches`) per chunk via `ak.materialize`. Used to probe how reading more branches affects wall-clock throughput while the analysis is running. The materialize block has its own `track_time` / `track_memory` spans.
 
-All four are passed to `run_processor_workflow()` in `src/intccms/analysis/runner.py`.
+All five are passed to `run_processor_workflow()` in `src/intccms/analysis/runner.py`.
 
 ### How do I write a custom processor?
 

--- a/cms/full_run_analysis_with_extra_branches.ipynb
+++ b/cms/full_run_analysis_with_extra_branches.ipynb
@@ -1,0 +1,728 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Analysis with extra branches read\n",
+    "\n",
+    "Runs the full CMS analysis flow (skim filter + CMSAnalysis + histograms) on the standard `example_cms` config, AND materialises an extra list of NanoAOD branches per chunk to probe whether reading more branches affects wall-clock throughput.\n",
+    "\n",
+    "The extra-branches list defaults to the fixed set used in `full_run_200gbps_replicate_legacy.ipynb` (the original idap-200gbps study branches), so throughput numbers can be compared against that benchmark."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "## Workflow Overview\n",
+    "\n",
+    "1. Setup Python path for intccms package\n",
+    "2. Install dependencies and register modules for cloud pickle\n",
+    "3. Acquire Dask client from AF environment\n",
+    "4. Configure analysis parameters (analysis on, histogramming on; extras supplied as a kwarg to the processor, not via `config.preprocess.branches`)\n",
+    "5. Run metadata extraction (`coffea` preprocessing)\n",
+    "6. Run `AnalysisWithExtraBranchesProcessor` with coffea.processor.Runner"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "## AF flag\n",
+    "We might want to run this code on different facilities, which may each have their own limitations or require different dask client setups. To make it easy to switch between facilities, just set the `AF` variable to the one of your choice. If your `AF` does not exist yet, you can introduce it in this notebook in the relevant sections."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "AF=\"coffeacasa-condor\" # options currently supported: [coffeacasa-condor, coffeacasa-gateway, purdue-af-k8s, purdue-af-slurm]\n",
+    "AUTO_CLOSE_CLIENT=False # the client setup is done with a contextmanager -- this flag decides if we automatically close the client as we exit the manager. If False, you handle closing manually. \n",
+    "n_workers = 800\n",
+    "chunksize = 500_000\n",
+    "WARM_XCACHE=False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4",
+   "metadata": {},
+   "source": [
+    "## Imports and dependencies"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5",
+   "metadata": {},
+   "source": [
+    "### The intccms package\n",
+    "The CMS implementation of the integration challenge is set in a package-like structure, which means we hae to add the source code to the python path. The package is referred to as `intccms`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Setup Python path to include intccms package\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# Add src directory to Python path\n",
+    "repo_root = Path.cwd()\n",
+    "src_dir = repo_root / \"src\"\n",
+    "examples_dir = repo_root\n",
+    "if str(src_dir) not in sys.path:\n",
+    "    sys.path.insert(0, str(src_dir))\n",
+    "if str(examples_dir) not in sys.path:\n",
+    "    sys.path.insert(0, str(examples_dir))\n",
+    "print(f\"✅ Added {src_dir} to Python path\")\n",
+    "print(f\"✅ Added {examples_dir} to Python path\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7",
+   "metadata": {},
+   "source": [
+    "### Installing extra dependencies\n",
+    "The `intccms` package requires `omegaconf` and `roastcoffea`, which is not by default on an AF. `roastcoffea` is a tool developed while working on this project and it provides an API to extract metrics from coffea-processor workflows. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import omegaconf\n",
+    "except ImportError:\n",
+    "    print(\"⚠️ omegaconf not found, installing...\")\n",
+    "    ! pip install omegaconf;\n",
+    "\n",
+    "try:\n",
+    "    import roastcoffea\n",
+    "except ImportError:\n",
+    "    print(\"⚠️ roastcoffea not found, installing...\")\n",
+    "    ! pip install roastcoffea;"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9",
+   "metadata": {},
+   "source": [
+    "### Alternative coffea version\n",
+    "In some cases, we might need to install our own `coffea` version which is not on the AF. For example, when testing a new feature or using a recently realased version with a fix."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "COFFEA_VERSION = \"2026.4.0\"\n",
+    "COFFEA_PIP = f\"coffea=={COFFEA_VERSION}\" if \"git\" not in COFFEA_VERSION else COFFEA_VERSION\n",
+    "\n",
+    "! pip install $COFFEA_PIP ;\n",
+    "\n",
+    "# Pip-installable dependencies to install on workers\n",
+    "WORKER_DEPENDENCIES = [COFFEA_PIP, \"roastcoffea==0.1.2\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11",
+   "metadata": {},
+   "source": [
+    "### Imports from stdlib and other libraries\n",
+    "\n",
+    "In this notebook we use `dask` and `coffea`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# stdlib\n",
+    "import cloudpickle\n",
+    "import copy\n",
+    "import os\n",
+    "import time\n",
+    "\n",
+    "from coffea.processor import DaskExecutor, IterativeExecutor\n",
+    "from coffea.nanoevents import NanoAODSchema"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13",
+   "metadata": {},
+   "source": [
+    "### Imports from intccms and other integration-challenge specific tooling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# intccms\n",
+    "from intccms.schema import Config, load_config_with_restricted_cli\n",
+    "from intccms.utils.output import OutputDirectoryManager\n",
+    "from intccms.metadata_extractor import DatasetMetadataManager\n",
+    "from intccms.datasets import DatasetManager\n",
+    "from intccms.analysis import run_processor_workflow, AnalysisWithExtraBranchesProcessor\n",
+    "from intccms.utils.tools import prepare_branches_from_list, warm_xcache\n",
+    "\n",
+    "# roastcoffea metrics\n",
+    "from roastcoffea import MetricsCollector"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15",
+   "metadata": {},
+   "source": [
+    "### Registering packages with cloudpickle\n",
+    "The intccms cannot be installed on the workers via `pip`, and the configuration files are in python modules which also cannot be installed on the workers. So we need to register them with `cloudpickle` to allow dask to serialize them and send them out."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import intccms\n",
+    "import example_cms\n",
+    "\n",
+    "# Register modules for cloud pickle\n",
+    "cloudpickle.register_pickle_by_value(intccms)\n",
+    "cloudpickle.register_pickle_by_value(example_cms)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17",
+   "metadata": {},
+   "source": [
+    "## Dask client setup\n",
+    "\n",
+    "This notebook uses the `DaskExecutor` from `coffea` to distribute the task graph on the AF. The client setup varies in different facilities, so we implement a function which returns the correct client. The function does so by providing a context manager, within which the client is alive."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from intccms.utils.dask_client import acquire_client, live_prints"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19",
+   "metadata": {},
+   "source": [
+    "## Configuration Setup\n",
+    "\n",
+    "Same configuration loading as `full_run.ipynb` (analysis flow). The extra branches to materialise are built from the same fixed BRANCH_LIST as `full_run_200gbps_replicate_legacy.ipynb`, and passed straight to the processor instead of overriding `config.preprocess.branches` (that field is still the skim's branch list and is left alone)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# intccms configuration import\n",
+    "from example_cms.configs.configuration import config as original_config\n",
+    "\n",
+    "# Create a deepcopy that we can manipulate\n",
+    "config = copy.deepcopy(original_config)\n",
+    "\n",
+    "# Limit files for testing\n",
+    "config[\"datasets\"][\"max_files\"] = None  # None would run over all available files\n",
+    "\n",
+    "# Use local output directory\n",
+    "config[\"general\"][\"output_dir\"] = \"example_cms/outputs_full_run_analysis_with_extra_branches/\"\n",
+    "\n",
+    "# Preprocessing (coffea) can be executed once and results loaded\n",
+    "config[\"general\"][\"run_metadata_generation\"] = True\n",
+    "\n",
+    "# Processor = skim filter + CMSAnalysis + materialise extra branches\n",
+    "config[\"general\"][\"run_processor\"] = True\n",
+    "config[\"general\"][\"run_analysis\"] = True\n",
+    "config[\"general\"][\"save_skimmed_output\"] = False  # filter on-the-fly, no disk output\n",
+    "config[\"general\"][\"run_histogramming\"] = True\n",
+    "config[\"general\"][\"run_systematics\"] = False\n",
+    "config[\"general\"][\"run_statistics\"] = False\n",
+    "\n",
+    "# ---------------------------------------------------------------------------\n",
+    "# Extra branches to materialise per chunk on top of the analysis read.\n",
+    "# Default = fixed list from idap-200gbps (the legacy 200 Gbps study) so\n",
+    "# throughput here can be compared directly with full_run_200gbps_replicate_legacy.ipynb.\n",
+    "# SAMPLE_MC_FILE / SAMPLE_DATA_FILE drive the MC-only branch split inside\n",
+    "# prepare_branches_from_list.\n",
+    "# ---------------------------------------------------------------------------\n",
+    "BRANCH_LIST = [\n",
+    "    \"GenPart_pt\", \"GenPart_eta\", \"GenPart_phi\", \"CorrT1METJet_phi\",\n",
+    "    \"GenJet_pt\", \"CorrT1METJet_eta\", \"SoftActivityJet_pt\",\n",
+    "    \"Jet_eta\", \"Jet_phi\", \"SoftActivityJet_eta\", \"SoftActivityJet_phi\",\n",
+    "    \"CorrT1METJet_rawPt\", \"Jet_btagDeepFlavB\", \"GenJet_eta\",\n",
+    "    \"GenPart_mass\", \"GenJet_phi\",\n",
+    "    \"Jet_puIdDisc\", \"CorrT1METJet_muonSubtrFactor\", \"Jet_btagDeepFlavCvL\",\n",
+    "    \"Jet_btagDeepFlavQG\", \"Jet_mass\", \"Jet_pt\", \"GenPart_pdgId\",\n",
+    "    \"Jet_btagDeepFlavCvB\", \"Jet_cRegCorr\",\n",
+    "]\n",
+    "\n",
+    "SAMPLE_MC_FILE = (\n",
+    "    \"root://xcache//store/mc/RunIISummer20UL16NanoAODv9/ZPrimeToTT_M2000_W200_TuneCP2_13TeV-madgraph-pythia8/NANOAODSIM/106X_mcRun2_asymptotic_v17-v2/2530000/288B512F-09A1-5D48-8D1B-6216C5904FB5.root\"\n",
+    ")\n",
+    "SAMPLE_DATA_FILE = (\n",
+    "    \"root://xcache//store/data/Run2016C/SingleMuon/NANOAOD/HIPM_UL2016_MiniAODv2_NanoAODv9-v2/40000/1D381615-0139-A540-AC3C-B3BC7C2B781F.root\"\n",
+    ")\n",
+    "\n",
+    "extra_branches, extra_mc_branches = prepare_branches_from_list(\n",
+    "    BRANCH_LIST,\n",
+    "    mc_file=SAMPLE_MC_FILE,\n",
+    "    data_file=SAMPLE_DATA_FILE,\n",
+    ")\n",
+    "\n",
+    "print(f\"Extra branches: {sum(len(v) for v in extra_branches.values())} fields across {len(extra_branches)} collections\")\n",
+    "print(f\"Extra MC-only branches: {sum(len(v) for v in extra_mc_branches.values())} fields\")\n",
+    "\n",
+    "print(extra_branches, \"\\n\", extra_mc_branches)\n",
+    "\n",
+    "cli_args = []\n",
+    "full_config = load_config_with_restricted_cli(config, cli_args)\n",
+    "validated_config = Config(**full_config)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21",
+   "metadata": {},
+   "source": [
+    "## Running the Workflow\n",
+    "\n",
+    "Same steps as `full_run.ipynb`:\n",
+    "\n",
+    "1. Setting up output directories\n",
+    "2. Building an input dataset manager\n",
+    "3. Running or loading the coffea preprocessing\n",
+    "4. Run the analysis-with-extra-branches processor"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22",
+   "metadata": {},
+   "source": [
+    "### Output manager setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output_manager = OutputDirectoryManager(\n",
+    "    root_output_dir=validated_config.general.output_dir,\n",
+    "    cache_dir=validated_config.general.cache_dir,\n",
+    "    metadata_dir=validated_config.general.metadata_dir,\n",
+    "    skimmed_dir=validated_config.general.skimmed_dir\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24",
+   "metadata": {},
+   "source": [
+    "### Configure Data Redirector (Optional)\n",
+    "\n",
+    "Override the redirector in the config for accessing dataset files. Useful for testing different storage backends. You can also change this in `example_cms/configs/skim.py`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Override redirector for all datasets\n",
+    "# Examples:\n",
+    "#   \"root://xcache/\"                    \n",
+    "#   \"root://cmsxrootd.fnal.gov/\"\n",
+    "#   \"root://cms-xrd-global.cern.ch/\"\n",
+    "REDIRECTOR = \"root://xcache/\"  # Change this to use a different redirector\n",
+    "\n",
+    "print(f\"Initial redirector  {validated_config.datasets.datasets[0].name}: {validated_config.datasets.datasets[0].redirector}\")\n",
+    "\n",
+    "# Apply to all datasets in config\n",
+    "for dataset in validated_config.datasets.datasets:\n",
+    " dataset.redirector = REDIRECTOR\n",
+    "\n",
+    "print(f\"Redirector set to: {REDIRECTOR}\")\n",
+    "\n",
+    "# Verify the change\n",
+    "print(f\"New redirector:  {validated_config.datasets.datasets[0].name}: {validated_config.datasets.datasets[0].redirector}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26",
+   "metadata": {},
+   "source": [
+    "### Input dataset manager setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_manager = DatasetManager(validated_config.datasets)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "28",
+   "metadata": {},
+   "source": [
+    "### Warm xcache\n",
+    "\n",
+    "Read all files once through xcache so they're cached before the benchmark."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if WARM_XCACHE:\n",
+    "    with acquire_client(AF, close_after=AUTO_CLOSE_CLIENT, pip_packages=WORKER_DEPENDENCIES, num_workers=n_workers) as (client, cluster):\n",
+    "        results, meta = warm_xcache(dataset_manager, client)\n",
+    "\n",
+    "    print(f\"Files: {meta['n_files']}\")\n",
+    "    print(f\"Total: {meta['total_GB']:.1f} GB in {meta['wall_time_s']:.1f}s\")\n",
+    "    print(f\"Throughput: {meta['total_Gbps']:.2f} Gbps (wall clock), {meta['per_worker_Gbps']:.2f} Gbps (per worker)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "30",
+   "metadata": {},
+   "source": [
+    "### Coffea preprocessing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "metadata_generator = DatasetMetadataManager(\n",
+    "    dataset_manager=dataset_manager,\n",
+    "    output_manager=output_manager,\n",
+    "    config=validated_config,\n",
+    "    chunksize=chunksize,\n",
+    ")\n",
+    "\n",
+    "if metadata_generator.generate_metadata:\n",
+    "  with acquire_client(AF, close_after=AUTO_CLOSE_CLIENT, pip_packages=WORKER_DEPENDENCIES, num_workers=n_workers) as (client, cluster):\n",
+    "      metadata_generator.run(executor=DaskExecutor(client=client))\n",
+    "else:\n",
+    "  metadata_generator.run()  # No client needed\n",
+    "\n",
+    "# Build metadata lookup and extract workitems\n",
+    "metadata_lookup = metadata_generator.build_metadata_lookup()\n",
+    "workitems = metadata_generator.workitems\n",
+    ";"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32",
+   "metadata": {},
+   "source": [
+    "### Run Analysis-With-Extra-Branches Processor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create the analysis-with-extra-branches processor\n",
+    "processor = AnalysisWithExtraBranchesProcessor(\n",
+    "    config=validated_config,\n",
+    "    output_manager=output_manager,\n",
+    "    metadata_lookup=metadata_lookup,\n",
+    "    extra_branches=extra_branches,\n",
+    "    extra_mc_branches=extra_mc_branches,\n",
+    ")\n",
+    "\n",
+    "# Run processor workflow with roastcoffea metrics collection\n",
+    "with acquire_client(AF, close_after=AUTO_CLOSE_CLIENT, pip_packages=WORKER_DEPENDENCIES, num_workers=n_workers) as (client, cluster):\n",
+    "    with MetricsCollector(\n",
+    "        client=client,\n",
+    "        processor_instance=processor,\n",
+    "        track_workers=True,\n",
+    "        worker_tracking_interval=1.0,\n",
+    "    ) as collector:\n",
+    "        t0 = time.perf_counter()\n",
+    "        output, report = run_processor_workflow(\n",
+    "            config=validated_config,\n",
+    "            output_manager=output_manager,\n",
+    "            metadata_lookup=metadata_lookup,\n",
+    "            processor=processor,\n",
+    "            workitems=workitems,\n",
+    "            executor=DaskExecutor(client=client, treereduction=8, retries=0),\n",
+    "            schema=NanoAODSchema,\n",
+    "            preload=True,\n",
+    "            chunksize=chunksize,\n",
+    "        )\n",
+    "        t1 = time.perf_counter()\n",
+    "\n",
+    "        # Extract chunk metrics injected by @track_metrics decorator\n",
+    "        collector.extract_metrics_from_output(output)\n",
+    "        collector.set_coffea_report(report)\n",
+    "\n",
+    "    try:\n",
+    "        client.profile(filename=f\"{output_manager.root_output_dir}/profiling/dask_profile_full_run_analysis_with_extra_branches.html\")\n",
+    "    except Exception as e:\n",
+    "        print(f\"⚠️  Dask profile capture failed: {e}\")\n",
+    "\n",
+    "    collector.save_measurement(f\"{output_manager.root_output_dir}/measurements\")\n",
+    "    # Get aggregated metrics after context exits\n",
+    "    metrics = collector.get_metrics()\n",
+    "    tracking_data = collector.tracking_data\n",
+    "    span_metrics = getattr(collector, \"span_metrics\", None)\n",
+    "\n",
+    "wall_time = t1 - t0\n",
+    "print(f\"Done in {wall_time:.1f} seconds\")\n",
+    "print(f\"Total events processed: {output.get('processed_events', 0):,}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34",
+   "metadata": {},
+   "source": [
+    "## Performance Metrics (roastcoffea)\n",
+    "\n",
+    "Summary tables and visualizations from the metrics collected during the run."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35",
+   "metadata": {},
+   "source": [
+    "### Summary Tables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rich.console import Console\n",
+    "from roastcoffea.export.reporter import (\n",
+    "    format_throughput_table,\n",
+    "    format_event_processing_table,\n",
+    "    format_resources_table,\n",
+    "    format_timing_table,\n",
+    "    format_fine_metrics_table,\n",
+    "    format_chunk_metrics_table,\n",
+    ")\n",
+    "\n",
+    "console = Console()\n",
+    "\n",
+    "print(\"Throughput Metrics\")\n",
+    "console.print(format_throughput_table(metrics))\n",
+    "\n",
+    "print(\"\\nEvent Processing Metrics\")\n",
+    "console.print(format_event_processing_table(metrics))\n",
+    "\n",
+    "print(\"\\nResource Utilization\")\n",
+    "console.print(format_resources_table(metrics))\n",
+    "\n",
+    "print(\"\\nTiming Breakdown\")\n",
+    "console.print(format_timing_table(metrics))\n",
+    "\n",
+    "print(\"\\nChunk Metrics (timing + memory per section)\")\n",
+    "chunk_table = format_chunk_metrics_table(metrics)\n",
+    "if chunk_table:\n",
+    "    console.print(chunk_table)\n",
+    "else:\n",
+    "    print(\"No chunk metrics available\")\n",
+    "\n",
+    "print(\"\\nFine-Grained Metrics (CPU/IO Breakdown)\")\n",
+    "console.print(format_fine_metrics_table(metrics))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37",
+   "metadata": {},
+   "source": [
+    "### Timeline Plots"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "38",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "from roastcoffea.visualization.plots import (\n",
+    "    plot_worker_count_timeline,\n",
+    "    plot_memory_utilization_mean_timeline,\n",
+    "    plot_memory_utilization_per_worker_timeline,\n",
+    "    plot_cpu_utilization_mean_timeline,\n",
+    "    plot_cpu_utilization_per_worker_timeline,\n",
+    "    plot_throughput_timeline,\n",
+    "    plot_per_task_cpu_io,\n",
+    "    plot_runtime_distribution,\n",
+    "    plot_runtime_vs_events,\n",
+    ")\n",
+    "\n",
+    "# Worker count over time\n",
+    "fig, ax = plot_worker_count_timeline(tracking_data)\n",
+    "plt.show()\n",
+    "\n",
+    "# Data throughput over time\n",
+    "fig, ax = plot_throughput_timeline(metrics[\"chunk_info\"], tracking_data)\n",
+    "plt.show()\n",
+    "from intccms.metrics.dataset_timeline import plot_dataset_timeline\n",
+    "\n",
+    "# ========================================================================\n",
+    "# Dataset processing timeline\n",
+    "# This shows how many chunks per dataset were active at each moment.\n",
+    "# ========================================================================\n",
+    "print(\"\\n📊 Dataset Processing Timeline\")\n",
+    "try:\n",
+    "  plot_dataset_timeline(collector.chunk_metrics, bin_seconds=1.0, output_manager=output_manager)\n",
+    "  plt.show()\n",
+    "except Exception as e:\n",
+    "  print(f\"⚠️  Dataset timeline plot unavailable: {e}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "39",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Memory utilization (mean across workers, then per-worker)\n",
+    "fig, ax = plot_memory_utilization_mean_timeline(tracking_data)\n",
+    "plt.show()\n",
+    "\n",
+    "fig, ax = plot_memory_utilization_per_worker_timeline(tracking_data)\n",
+    "plt.show()\n",
+    "\n",
+    "# CPU utilization (mean across workers, then per-worker)\n",
+    "fig, ax = plot_cpu_utilization_mean_timeline(tracking_data)\n",
+    "plt.show()\n",
+    "\n",
+    "fig, ax = plot_cpu_utilization_per_worker_timeline(tracking_data)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40",
+   "metadata": {},
+   "source": [
+    "### Task and Processor Breakdown"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# CPU vs non-CPU time per task (from Dask Spans)\n",
+    "if span_metrics:\n",
+    "    fig, ax = plot_per_task_cpu_io(span_metrics)\n",
+    "    plt.show()\n",
+    "else:\n",
+    "    print(\"Span metrics not available\")\n",
+    "\n",
+    "# Chunk runtime distribution\n",
+    "fig, ax = plot_runtime_distribution(metrics.get(\"raw_chunk_metrics\"))\n",
+    "plt.show()\n",
+    "\n",
+    "# Runtime vs number of events (scaling behavior)\n",
+    "fig, ax = plot_runtime_vs_events(metrics.get(\"raw_chunk_metrics\"))\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/cms/src/intccms/analysis/__init__.py
+++ b/cms/src/intccms/analysis/__init__.py
@@ -5,6 +5,7 @@ from . import cms as cms
 from .base import Analysis
 from .cms import CMSAnalysis
 from .processors import (
+    AnalysisWithExtraBranchesProcessor,
     HistLocalProcessor,
     HistServProcessor,
     SkimAndAnalyseProcessor,
@@ -22,6 +23,7 @@ __all__ = [
     "TwoHundredGbpsProcessor",
     "HistServProcessor",
     "HistLocalProcessor",
+    "AnalysisWithExtraBranchesProcessor",
     "run_processor_workflow",
 ]
 

--- a/cms/src/intccms/analysis/processors.py
+++ b/cms/src/intccms/analysis/processors.py
@@ -831,3 +831,143 @@ class TwoHundredGbpsProcessor(ProcessorABC):
         )
         return accumulator
 
+
+class AnalysisWithExtraBranchesProcessor(ProcessorABC):
+    """Coffea processor that runs analysis and materializes extra branches.
+
+    Combines the analysis path of :class:`HistLocalProcessor` (skim filter +
+    :class:`CMSAnalysis`, no disk output) with the branch-reading behaviour of
+    :class:`TwoHundredGbpsProcessor`. After the skim filter, a user-supplied
+    dict of extra branches is read off disk via ``ak.materialize`` to probe
+    how reading more branches affects wall-clock throughput.
+
+    No file saving, no manifests, no ROOT output, no statistics.
+
+    Attributes
+    ----------
+    config : Config
+        Full analysis configuration
+    output_manager : OutputDirectoryManager
+        Manager for output directory paths
+    metadata_lookup : Dict[str, Dict[str, Any]]
+        Pre-built metadata lookup mapping fileset_key to metadata dict
+    extra_columns_to_keep : List[str]
+        Flat list of extra branches to materialize
+    extra_mc_only_columns : List[str]
+        Flat list of MC-only entries within the extras
+    """
+
+    def __init__(
+        self,
+        config: Config,
+        output_manager: OutputDirectoryManager,
+        metadata_lookup: Dict[str, Dict[str, Any]],
+        extra_branches: Dict[str, List[str]],
+        extra_mc_branches: Optional[Dict[str, List[str]]] = None,
+    ):
+        """Initialize AnalysisWithExtraBranchesProcessor.
+
+        Parameters
+        ----------
+        config : Config
+            Full analysis configuration with general.run_* flags
+        output_manager : OutputDirectoryManager
+            For resolving output paths
+        metadata_lookup : Dict[str, Dict[str, Any]]
+            Pre-built metadata lookup from
+            NanoAODMetadataGenerator.build_metadata_lookup()
+        extra_branches : Dict[str, List[str]]
+            Extra branches to materialize per chunk, in the same
+            ``{collection: [branches]}`` shape as ``config.preprocess.branches``.
+        extra_mc_branches : Dict[str, List[str]], optional
+            MC-only entries within ``extra_branches``. Same shape as
+            ``config.preprocess.mc_branches``.
+        """
+        self.config = config
+        self.output_manager = output_manager
+        self.metadata_lookup = metadata_lookup
+        self.skim_config = config.preprocess.skimming
+
+        self.extra_columns_to_keep, self.extra_mc_only_columns = build_column_list(
+            extra_branches,
+            extra_mc_branches,
+            is_data=False,  # filtered per-chunk in process()
+        )
+
+        self.analysis = CMSAnalysis(
+            config=config,
+            output_manager=output_manager,
+        )
+
+        logger.info(
+            f"Initialized AnalysisWithExtraBranchesProcessor: "
+            f"analysis={config.general.run_analysis}, "
+            f"histogramming={config.general.run_histogramming}, "
+            f"systematics={config.general.run_systematics}, "
+            f"{len(self.extra_columns_to_keep)} extra branches to materialize"
+        )
+
+    @property
+    def accumulator(self):
+        """Define accumulator structure based on enabled stages."""
+        acc = {"processed_events": 0}
+        if self.config.general.run_histogramming:
+            acc["histograms"] = self.analysis.nD_hists_per_region
+        return acc
+
+    @track_metrics
+    def process(self, events: ak.Array) -> Dict[str, Any]:
+        """Process a single chunk of events."""
+        output = self.accumulator
+
+        dataset_name = events.metadata["dataset"]
+        metadata = self.metadata_lookup.get(dataset_name)
+
+        if not metadata:
+            logger.warning(f"No metadata found for dataset {dataset_name}, skipping chunk")
+            output["processed_events"] = 0
+            return output
+
+        input_events_count = len(events)
+
+        # Apply skim selection (filter always applies)
+        with track_time(self, "skim_selection"):
+            executor = SelectionExecutor(self.skim_config)
+            events = events[executor.execute(events)]
+
+        # Materialize the configured extra branches on the surviving events
+        is_data = metadata.get("is_data", False)
+        with track_time(self, "extract_columns"), track_memory(self, "extract_columns"):
+            extra_columns = extract_columns(
+                events,
+                self.extra_columns_to_keep,
+                mc_only_columns=self.extra_mc_only_columns,
+                is_data=is_data,
+            )
+        branches_read = set()
+        with track_time(self, "materialize"), track_memory(self, "materialize"):
+            for key, arr in extra_columns.items():
+                try:
+                    ak.materialize(arr)
+                    branches_read.add(key)
+                except Exception as e:
+                    print(e)
+                    if "unrecognized compression algorithm" in str(e) or "lzma data error" in str(e):
+                        continue
+                    else:
+                        raise e
+        output["branches_read"] = branches_read
+
+        if self.config.general.run_analysis and len(events) > 0:
+            with track_time(self, "analysis"):
+                self.analysis.process(events=events, metadata=metadata)
+            if self.config.general.run_histogramming:
+                output["histograms"] = self.analysis.nD_hists_per_region
+
+        output["processed_events"] = input_events_count
+        return output
+
+    def postprocess(self, accumulator: Dict) -> Dict:
+        """Finalize accumulator after all chunks processed."""
+        return accumulator
+


### PR DESCRIPTION
## Summary

Adds `AnalysisWithExtraBranchesProcessor` in `intccms.analysis`. It runs the same skim filter + `CMSAnalysis` flow as `HistLocalProcessor`, and between the filter and the analysis call it materialises an arbitrary user-supplied list of extra NanoAOD branches via `extract_columns` + `ak.materialize`. The materialise block is wrapped in `track_time` / `track_memory` so the cost shows up in roastcoffea metrics.

The extras list is a constructor kwarg (`extra_branches: Dict[str, List[str]]`, optional `extra_mc_branches`), not a new config field. `config.preprocess.branches` is untouched (still the skim's branch list).

Also adds `full_run_analysis_with_extra_branches.ipynb`. It loads the standard `example_cms` analysis config with `run_analysis=True` and `run_histogramming=True`, and defaults `extra_branches` to the fixed idap-200gbps BRANCH_LIST from `full_run_200gbps_replicate_legacy.ipynb` so throughput numbers here can be compared directly with that benchmark.

The point of this is to test whether reading more branches changes wall-clock throughput when the analysis is also running.