### PR TITLE
feat: add baseline event selection in ServiceX preskim

### DIFF
--- a/cms/README.md
+++ b/cms/README.md
@@ -441,10 +441,11 @@ config["general"]["servicex"] = {
         "ignore_local_cache": False,
     },
     "use_s3": True,          # if using S3 for ServiceX outputs, we need to pass encoded=True to uproot.open() to read S3 URLs
+    "apply_baseline_selection": True, # if True, ServiceX will apply event cuts as defined in baseline_selection_config in configuration.py.
 }
 ```
+NOTE: if `apply_baseline_selection=True`, the Docker image used by Python code generator in ServiceX must have Coffea package installed. This is not done for default image used by ServiceX, but can be achieved with a custom image. For testing purposes, the following image can be used: `docker.io/sslhep/servicex_science_image_combined_root:5.7.4-6.38.04@sha256:dc101f071c09908bc6475c822b7c4a98e8ee9b40c19b2a838ad69c509d7e5213`.
 
-At the moment, ServiceX skimming implements branch/column skimming only (no event-level selection yet).
 
 ### How do I skim events with Coffea processor?
 

--- a/cms/full_run_servicex_preskim.ipynb
+++ b/cms/full_run_servicex_preskim.ipynb
@@ -264,6 +264,7 @@
     "    \"fail_if_incomplete\": True,\n",
     "    \"ignore_local_cache\": True, # start new transformers every time instead of reusing cached outputs - for testing purposes\n",
     "}\n",
+    "config[\"general\"][\"servicex\"][\"apply_baseline_selection\"] = True\n",
     "\n",
     "# Datasets to process, by default this is all datasets\n",
     "#config[\"general\"][\"processes\"] = [\"data\"] \n",

--- a/cms/src/intccms/metadata_extractor/manager.py
+++ b/cms/src/intccms/metadata_extractor/manager.py
@@ -248,6 +248,11 @@ class DatasetMetadataManager:
                 self.fileset,
                 preprocess_config,
                 servicex_deliver_kwargs=self.config.general.servicex.deliver_kwargs,
+                selection_config=(
+                    self.config.baseline_selection
+                    if self.config.general.servicex.apply_baseline_selection
+                    else None
+                ),
             )
         self.fileset_builder.save_fileset(self.fileset)
 

--- a/cms/src/intccms/metadata_extractor/servicex_preskim.py
+++ b/cms/src/intccms/metadata_extractor/servicex_preskim.py
@@ -4,14 +4,16 @@ One batched :func:`servicex.deliver` over all datasets; returns a fileset whose 
 keys are output URLs.
 """
 
+import inspect
 import logging
+import textwrap
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 from intccms.utils.tools import dict_to_branches
 
 logger = logging.getLogger(__name__)
 
-Task = Tuple[str, Dict[str, Any], List[str], str, List[str]]
+Task = Tuple[str, Dict[str, Any], List[str], str, List[str], Optional[str]]
 
 
 def _skimming_columns(preprocess_config: Any, is_data: bool) -> List[str]:
@@ -58,6 +60,50 @@ def _silence_verbose_servicex_loggers() -> None:
         logging.getLogger(name).setLevel(logging.WARNING)
 
 
+def _selection_to_cut(selection_config: Any, columns: List[str]) -> str:
+    """Build a ServiceX ``PythonFunction`` source string from a selection config.
+
+    The returned string defines ``run_query(input_filenames=None)`` that embeds
+    the selection function, reads ``columns`` (assumed to already include all
+    branches needed for the selection), assembles NanoAOD collections via
+    ``ak.zip``, and returns ``{"Events": filtered, "LuminosityBlocks": ..., "Runs": ...}``.
+    ``PackedSelection.all(*sel.names)`` is used to extract the combined mask.
+    """
+    func = selection_config.function
+    use_spec = selection_config.use or []
+
+    collections_strings = ""
+    call_args: List[str] = []
+    for obj, _ in use_spec:
+        obj_cols = [col for col in columns if col.startswith(f"{obj}_")]
+        zip_dict = ", ".join(f'"{col[len(obj) + 1:]}": events["{col}"]' for col in obj_cols)
+        var = obj.lower()
+        collections_strings += f"        {var} = ak.zip({{{zip_dict}}})\n"
+        call_args.append(var)
+
+    columns_needed = list(columns)
+    func_src = textwrap.indent(textwrap.dedent(inspect.getsource(func)).strip(), "    ")
+
+    return f"""\
+def run_query(input_filenames=None):
+    import uproot
+    import awkward as ak
+    from coffea.analysis_tools import PackedSelection
+
+{func_src}
+
+    columns_needed = {columns_needed!r}
+    with uproot.open(input_filenames) as f:
+        columns_avail = set(f['Events'].keys())
+        events = f['Events'].arrays([b for b in columns_needed if b in columns_avail], library='ak')
+{collections_strings}
+        sel = {func.__name__}({', '.join(call_args)})
+        mask = sel.all(*sel.names)
+        lumi = f['LuminosityBlocks'].arrays(library='ak') if 'LuminosityBlocks' in f else ak.Array([])
+        runs = f['Runs'].arrays(library='ak') if 'Runs' in f else ak.Array([])
+    return {{'Events': events[mask], 'LuminosityBlocks': lumi, 'Runs': runs}}"""
+
+
 def _deliver_tasks(tasks: List[Task], deliver_kwargs: Dict[str, Any]) -> Dict[str, Any]:
     """Build ServiceX query and run one ``servicex.deliver`` call which will submit
     transformer pods in parallel."""
@@ -70,22 +116,26 @@ def _deliver_tasks(tasks: List[Task], deliver_kwargs: Dict[str, Any]) -> Dict[st
 
     _silence_verbose_servicex_loggers()
     samples: List[Dict[str, Any]] = []
-    for dataset_key, _, input_files, treename, columns in tasks:
+    for dataset_key, _, input_files, treename, columns, cut in tasks:
+        if cut is not None:
+            servicex_query = query.PythonFunction(cut)
+        else:
+            servicex_query = query.UprootRaw(
+                [
+                    {
+                        "treename": treename,
+                        "filter_name": columns,
+                        "fail_on_missing_trees": True,
+                    },
+                    {"treename": "LuminosityBlocks"},
+                    {"treename": "Runs"},
+                ]
+            )
         samples.append(
             {
                 "Name": f"sx_{dataset_key}",
                 "Dataset": dataset.FileList(input_files),
-                "Query": query.UprootRaw(
-                    [
-                        {
-                            "treename": treename,
-                            "filter_name": columns,
-                            "fail_on_missing_trees": True,
-                        },
-                        {"treename": "LuminosityBlocks"},
-                        {"treename": "Runs"},
-                    ]
-                ),
+                "Query": servicex_query,
             }
         )
     spec = {"General": {"Delivery": "URLs"}, "Sample": samples}
@@ -100,6 +150,7 @@ class ServiceXMetadataSkimmer:
         input_fileset: Dict[str, Dict[str, Any]],
         preprocess_config: Any,
         servicex_deliver_kwargs: Optional[Dict[str, Any]] = None,
+        selection_config: Optional[Any] = None,
     ) -> Dict[str, Dict[str, Any]]:
         """Return a copy of the fileset with ``files`` keys replaced by ServiceX output paths/urls.
 
@@ -112,6 +163,11 @@ class ServiceXMetadataSkimmer:
         servicex_deliver_kwargs
             Keyword arguments forwarded to ``servicex.deliver`` (e.g.
             ``general.servicex.deliver_kwargs`` from the analysis config).
+        selection_config
+            Optional baseline selection config (e.g. ``config.baseline_selection``).
+            When provided, its ``function`` and ``use`` spec are compiled into a
+            ServiceX ``PythonFunction`` query that filters events on the transformer
+            workers before delivery.
         """
         deliver_kwargs: Dict[str, Any] = dict(servicex_deliver_kwargs or {})
         tasks: List[Task] = []
@@ -127,13 +183,26 @@ class ServiceXMetadataSkimmer:
                 )
                 continue
             treename = next(iter(files.values()), "Events")
+            columns = _skimming_columns(preprocess_config, is_data)
+            cut = (
+                _selection_to_cut(selection_config, columns)
+                if selection_config is not None
+                else None
+            )
+            if cut is not None:
+                logger.debug(
+                    "Compiled ServiceX PythonFunction for '%s':\n%s",
+                    dataset_key,
+                    cut,
+                )
             tasks.append(
                 (
                     dataset_key,
                     metadata,
                     input_files,
                     treename,
-                    _skimming_columns(preprocess_config, is_data),
+                    columns,
+                    cut,
                 )
             )
 
@@ -147,7 +216,7 @@ class ServiceXMetadataSkimmer:
         delivered = _deliver_tasks(tasks, deliver_kwargs)
 
         out: Dict[str, Dict[str, Any]] = {}
-        for dataset_key, metadata, _, treename, _ in tasks:
+        for dataset_key, metadata, _, treename, _, _ in tasks:
             name = f"sx_{dataset_key}"
             urls = _flatten_delivered_urls(delivered[name])
             out[dataset_key] = {

--- a/cms/src/intccms/schema/analysis.py
+++ b/cms/src/intccms/schema/analysis.py
@@ -128,6 +128,14 @@ class ServicexConfig(SubscriptableModel):
             "(percent-encoded ServiceX S3/HTTP URLs).",
         ),
     ]
+    apply_baseline_selection: Annotated[
+        bool,
+        Field(
+            default=False,
+            description="If True, apply ``baseline_selection`` as a cut inside the ServiceX "
+            "preskim query, filtering events on the transformer workers before delivery.",
+        ),
+    ]
 
 
 class GeneralConfig(SubscriptableModel):


### PR DESCRIPTION
This is a follow-up on #69 which adds baseline event selection as a cut in the ServiceX query. Instead of `UprootRaw` query, type, we use `PythonFunction` query here, and the function is automatically constructed from the selector function defined in `baseline_selection_config`. 

(Maybe in the future ServiceX could support Coffea event selections natively as a query type?)

For this to work, ServiceX needs to be configured as follows:
* Python codeGen should be enabled
* transformer ("science") image used by the Python codeGen must have Coffea installed, to be able to import PackedSelection. Default image doesn't have it, therefore for now I'm leaving this event selection disabled by default.